### PR TITLE
add support for symbolic links in targz

### DIFF
--- a/targz.go
+++ b/targz.go
@@ -128,7 +128,9 @@ func untarGzFile(tr *tar.Reader, header *tar.Header, destination string) error {
 	case tar.TypeDir:
 		return mkdir(filepath.Join(destination, header.Name))
 	case tar.TypeReg:
-		return writeNewFile(filepath.Join(destination, header.Name), tr)
+		return writeNewFile(filepath.Join(destination, header.Name), tr, header.FileInfo().Mode())
+	case tar.TypeSymlink:
+		return writeNewSymbolicLink(filepath.Join(destination, header.Name), header.Linkname)
 	default:
 		return fmt.Errorf("%s: unknown type flag: %c", header.Name, header.Typeflag)
 	}

--- a/targz.go
+++ b/targz.go
@@ -76,17 +76,18 @@ func tarGzFile(tarWriter *tar.Writer, source string) error {
 			return nil
 		}
 
-		file, err := os.Open(path)
-		if err != nil {
-			return fmt.Errorf("%s: open: %v", path, err)
-		}
-		defer file.Close()
+		if header.Typeflag == tar.TypeReg {
+			file, err := os.Open(path)
+			if err != nil {
+				return fmt.Errorf("%s: open: %v", path, err)
+			}
+			defer file.Close()
 
-		_, err = io.Copy(tarWriter, file)
-		if err != nil {
-			return fmt.Errorf("%s: copying contents: %v", path, err)
+			_, err = io.Copy(tarWriter, file)
+			if err != nil {
+				return fmt.Errorf("%s: copying contents: %v", path, err)
+			}
 		}
-
 		return nil
 	})
 }


### PR DESCRIPTION
- symbolic links within a targz were not being written (failing instead). 
- Also, file mode was defaulting to 0666, rather than its original value.

When attempting to untar the Oracle Jdk1.8 tar file, it will fail, because there are 3 symbolic links in the tar file. This change adds support for symbolic links.