### PR TITLE
add support for symbolic links and preserve file mode.

### DIFF
--- a/zip.go
+++ b/zip.go
@@ -146,10 +146,8 @@ func writeNewFile(fpath string, in io.Reader, fm os.FileMode) error {
 	defer out.Close()
 
 	err = out.Chmod(fm)
-	if err != nil {
-		if runtime.GOOS != "windows" {
-			return fmt.Errorf("%s: changing file mode: %v", fpath, err)
-		}
+	if err != nil && runtime.GOOS != "windows" {
+		return fmt.Errorf("%s: changing file mode: %v", fpath, err)
 	}
 
 	_, err = io.Copy(out, in)

--- a/zip.go
+++ b/zip.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -84,15 +85,17 @@ func zipFile(w *zip.Writer, source string) error {
 			return nil
 		}
 
-		file, err := os.Open(fpath)
-		if err != nil {
-			return fmt.Errorf("%s: opening: %v", fpath, err)
-		}
-		defer file.Close()
+		if header.Mode().IsRegular() {
+			file, err := os.Open(fpath)
+			if err != nil {
+				return fmt.Errorf("%s: opening: %v", fpath, err)
+			}
+			defer file.Close()
 
-		_, err = io.Copy(writer, file)
-		if err != nil {
-			return fmt.Errorf("%s: copying contents: %v", fpath, err)
+			_, err = io.Copy(writer, file)
+			if err != nil {
+				return fmt.Errorf("%s: copying contents: %v", fpath, err)
+			}
 		}
 
 		return nil
@@ -127,10 +130,10 @@ func unzipFile(zf *zip.File, destination string) error {
 	}
 	defer rc.Close()
 
-	return writeNewFile(filepath.Join(destination, zf.Name), rc)
+	return writeNewFile(filepath.Join(destination, zf.Name), rc, zf.FileInfo().Mode())
 }
 
-func writeNewFile(fpath string, in io.Reader) error {
+func writeNewFile(fpath string, in io.Reader, fm os.FileMode) error {
 	err := os.MkdirAll(path.Dir(fpath), 0755)
 	if err != nil {
 		return fmt.Errorf("%s: making directory for file: %v", fpath, err)
@@ -142,10 +145,31 @@ func writeNewFile(fpath string, in io.Reader) error {
 	}
 	defer out.Close()
 
+	err = out.Chmod(fm)
+	if err != nil {
+		if runtime.GOOS != "windows" {
+			return fmt.Errorf("%s: changing file mode: %v", fpath, err)
+		}
+	}
+
 	_, err = io.Copy(out, in)
 	if err != nil {
 		return fmt.Errorf("%s: writing file: %v", fpath, err)
 	}
+	return nil
+}
+
+func writeNewSymbolicLink(fpath string, target string) error {
+	err := os.MkdirAll(path.Dir(fpath), 0755)
+	if err != nil {
+		return fmt.Errorf("%s: making directory for file: %v", fpath, err)
+	}
+
+	err = os.Symlink(target, fpath)
+	if err != nil {
+		return fmt.Errorf("%s: making symbolic link for: %v", fpath, err)
+	}
+
 	return nil
 }
 

--- a/zip_test.go
+++ b/zip_test.go
@@ -65,17 +65,29 @@ func symmetricTest(t *testing.T, ext string, cf CompressFunc, dcf DecompressFunc
 			return nil
 		}
 
+		expectedFileInfo, err := os.Stat(origPath)
+		if err != nil {
+			t.Fatalf("%s: Error obtaining original file info: %v", fpath, err)
+		}
 		expected, err := ioutil.ReadFile(origPath)
 		if err != nil {
 			t.Fatalf("%s: Couldn't open original file (%s) from disk: %v",
 				fpath, origPath, err)
 		}
 
+		actualFileInfo, err := os.Stat(fpath)
+		if err != nil {
+			t.Fatalf("%s: Error obtaining actual file info: %v", fpath, err)
+		}
 		actual, err := ioutil.ReadFile(fpath)
 		if err != nil {
 			t.Fatalf("%s: Couldn't open new file from disk: %v", fpath, err)
 		}
 
+		if actualFileInfo.Mode() != expectedFileInfo.Mode() {
+			t.Fatalf("%s: File mode differed between on disk and compressed",
+				expectedFileInfo.Mode().String()+" : "+actualFileInfo.Mode().String())
+		}
 		if !bytes.Equal(expected, actual) {
 			t.Fatalf("%s: File contents differed between on disk and compressed", origPath)
 		}


### PR DESCRIPTION
Currently, while decrompressing (extracting files), if any are a symbolic link, archiver will fail. This change adds in support for the tar(gz) format to open, and create tar archives with symbolic links.
Zip files, do not support symbolic links, but this update does allow them to exist, merely skipping over them. There appears to be an issue with zip files and symbolic links.

This change, also preserves the file mode, and chmod according to original file mode. (Not applicable on Windows build)
Working on testing this. Currently the included tests attempt to compress, decompress all the files in test data. I need to write a test that will prevent zip files from messing with the symbolic links.