### PR TITLE
can't `UntarGz` some archives

### DIFF
--- a/targz.go
+++ b/targz.go
@@ -128,7 +128,7 @@ func untarGzFile(tr *tar.Reader, header *tar.Header, destination string) error {
 	switch header.Typeflag {
 	case tar.TypeDir:
 		return mkdir(filepath.Join(destination, header.Name))
-	case tar.TypeReg:
+	case tar.TypeReg, tar.TypeRegA:
 		return writeNewFile(filepath.Join(destination, header.Name), tr, header.FileInfo().Mode())
 	case tar.TypeSymlink:
 		return writeNewSymbolicLink(filepath.Join(destination, header.Name), header.Linkname)


### PR DESCRIPTION
`tar.TypeRegA` should be cared. 

Following code doesn't work with Error `pt_linux_amd64/pt: unknown type flag:`.

```go
package main

import (
	"fmt"
	"io"
	"net/http"
	"os"
	"path"

	"github.com/mholt/archiver"
)

func main() {
	url := "https://github.com/monochromegane/the_platinum_searcher/releases/download/v2.1.2/pt_linux_amd64.tar.gz"
	resp, _ := http.Get(url)
	defer resp.Body.Close()
	fname := path.Base(url)
	f, _ := os.Create(fname)
	io.Copy(f, resp.Body)

	err := archiver.UntarGz(fname, "pt")
	if err != nil {
		fmt.Println(err.Error())
	}
}
```

This patch resolve it.