### PR TITLE
parsing header.Name (filepath) for subfolders

### DIFF
--- a/rar.go
+++ b/rar.go
@@ -70,8 +70,6 @@ func Unrar(source, destination string) error {
 func makeSubfolders(path string, destination string) {
 	// parse path for subfolders
 	for _, subfolder := range strings.Split(path, "/") {
-		filepath.Dir(subfolder)
-
 		// check to see if the subfolder exists already
 		if stat, err := os.Stat(destination + subfolder); err != nil || !stat.IsDir() {
 			// make the directory

--- a/rar.go
+++ b/rar.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/nwaples/rardecode"
 )
@@ -36,6 +37,23 @@ func Unrar(source, destination string) error {
 			break
 		} else if err != nil {
 			return err
+		}
+		
+		pathComponents := strings.Split(header.Name, "/")
+
+		for pi, path := range pathComponents {
+			// the last component of the path will be the file
+			// so ignore it, since we only want to create folders
+			if pi == len(pathComponents)-1 {
+				continue
+			}
+
+			// check to see if the path exists already
+			if stat, err := os.Stat(destination + path); err != nil || !stat.IsDir() {
+				// make the directory
+				mkdir(destination + path)
+				continue
+			}
 		}
 
 		if header.IsDir {


### PR DESCRIPTION
While trying to unrar an archive with subfolders, the call to header.IsDir evaluates as false because the folder structure does not exist yet. This is a less than ideal way to parse the path for subfolders and create them as needed before header.IsDir is checked against.