### PR TITLE
fix copying contents: archive/tar: write too long

### DIFF
--- a/targz.go
+++ b/targz.go
@@ -95,7 +95,7 @@ func tarFile(tarWriter *tar.Writer, source, dest string) error {
 			}
 			defer file.Close()
 
-			_, err = io.Copy(tarWriter, file)
+			_, err = io.CopyN(tarWriter, file,info.Size())
 			if err != nil {
 				return fmt.Errorf("%s: copying contents: %v", path, err)
 			}

--- a/targz.go
+++ b/targz.go
@@ -95,8 +95,8 @@ func tarFile(tarWriter *tar.Writer, source, dest string) error {
 			}
 			defer file.Close()
 
-			_, err = io.CopyN(tarWriter, file,info.Size())
-			if err != nil && err!= io.EOF{
+			_, err = io.CopyN(tarWriter, file, info.Size())
+			if err != nil && err != io.EOF {
 				return fmt.Errorf("%s: copying contents: %v", path, err)
 			}
 		}

--- a/targz.go
+++ b/targz.go
@@ -96,7 +96,7 @@ func tarFile(tarWriter *tar.Writer, source, dest string) error {
 			defer file.Close()
 
 			_, err = io.CopyN(tarWriter, file,info.Size())
-			if err != nil {
+			if err != nil && err!= io.EOF{
 				return fmt.Errorf("%s: copying contents: %v", path, err)
 			}
 		}

--- a/zip.go
+++ b/zip.go
@@ -94,7 +94,7 @@ func zipFile(w *zip.Writer, source string) error {
 			defer file.Close()
 
             _, err = io.CopyN(writer, file, info.Size())
-			if err != nil {
+			if err != nil && err!= io.EOF{
 				return fmt.Errorf("%s: copying contents: %v", fpath, err)
 			}
 		}

--- a/zip.go
+++ b/zip.go
@@ -93,8 +93,8 @@ func zipFile(w *zip.Writer, source string) error {
 			}
 			defer file.Close()
 
-            _, err = io.CopyN(writer, file, info.Size())
-			if err != nil && err!= io.EOF{
+			_, err = io.CopyN(writer, file, info.Size())
+			if err != nil && err != io.EOF {
 				return fmt.Errorf("%s: copying contents: %v", fpath, err)
 			}
 		}

--- a/zip.go
+++ b/zip.go
@@ -93,7 +93,7 @@ func zipFile(w *zip.Writer, source string) error {
 			}
 			defer file.Close()
 
-			_, err = io.Copy(writer, file)
+            _, err = io.CopyN(writer, file, info.Size())
 			if err != nil {
 				return fmt.Errorf("%s: copying contents: %v", fpath, err)
 			}


### PR DESCRIPTION
When file is in use and size getting increased , create compressed file will failed and error is "copying contents: archive/tar: write too long".  Changing to use CopyN to copy only the file size at that time,  also checks io.EOF if file becomes small.