### PR TITLE
use filepath.Dir() instead of path.Dir()

### DIFF
--- a/zip.go
+++ b/zip.go
@@ -135,7 +135,7 @@ func unzipFile(zf *zip.File, destination string) error {
 }
 
 func writeNewFile(fpath string, in io.Reader, fm os.FileMode) error {
-	err := os.MkdirAll(path.Dir(fpath), 0755)
+	err := os.MkdirAll(filepath.Dir(fpath), 0755)
 	if err != nil {
 		return fmt.Errorf("%s: making directory for file: %v", fpath, err)
 	}
@@ -159,7 +159,7 @@ func writeNewFile(fpath string, in io.Reader, fm os.FileMode) error {
 }
 
 func writeNewSymbolicLink(fpath string, target string) error {
-	err := os.MkdirAll(path.Dir(fpath), 0755)
+	err := os.MkdirAll(filepath.Dir(fpath), 0755)
 	if err != nil {
 		return fmt.Errorf("%s: making directory for file: %v", fpath, err)
 	}


### PR DESCRIPTION
Please use filepath.Dir(), not path.Dir().

In Windows, following code doesn't work with Error
 `peco_windows_amd64\peco_windows_amd64\Changes: creating new file: open peco_windows_amd64\peco_windows_amd64\Changes: The system cannot find the path specified.`

```
package main

import (
	"fmt"
	"io"
	"net/http"
	"os"
	"path"

	"github.com/mholt/archiver"
)

func main() {
	url := "https://github.com/peco/peco/releases/download/v0.4.0/peco_windows_amd64.zip"
	resp, _ := http.Get(url)
	defer resp.Body.Close()
	fname := path.Base(url)
	f, _ := os.Create(fname)
	io.Copy(f, resp.Body)

	err := archiver.Unzip(fname, "peco_windows_amd64")
	if err != nil {
		fmt.Println(err.Error())
	}
}
  
```

And following code doesn't extract .tar.gz file including symlink with Error: `dest\hoge.txt: creating new file: open dest\hoge.txt: The system cannot find the path specified.`

```
$ tar -tvf hoge.tar.gz
-rw-r--r-- username/197121     0 2016-08-20 14:35 hoge.txt
lrwxrwxrwx username/197121     0 2016-08-20 14:12 link -> hoge.txt
```

```
package main

import (
	"fmt"

	"github.com/mholt/archiver"
)

func main() {
	err := archiver.UntarGz("hoge.tar.gz", "dest")
	if err != nil {
		fmt.Println(err.Error())
	}
```
