### PR TITLE
Use path.Join when setting zip.FileHeader.Name.

### DIFF
--- a/zip.go
+++ b/zip.go
@@ -62,7 +62,7 @@ func zipFile(w *zip.Writer, source string) error {
 		}
 
 		if baseDir != "" {
-			header.Name = filepath.Join(baseDir, strings.TrimPrefix(fpath, source))
+			header.Name = path.Join(baseDir, strings.TrimPrefix(fpath, source))
 		}
 
 		if info.IsDir() {


### PR DESCRIPTION
`zip.FileHeader.Name` is documented to be a `/`-separated path,
rather than an `os.PathSeparator`-separated file system path:

	// Name is the name of the file.
	// It must be a relative path: it must not start with a drive
	// letter (e.g. C:) or leading slash, and only forward slashes
	// are allowed.

Source: https://godoc.org/archive/zip#FileHeader.Name

Therefore, it's correct to use `path.Join` rather than `filepath.Join`
when setting its value. Package [path](https://godoc.org/path) manipulates and produces
slash-separated paths, while package [filepath](https://godoc.org/path/filepath) manipulates and
produces `os.PathSeparator`-separated file system paths.

Updates https://github.com/mholt/archiver/pull/9#issuecomment-241184865.