### PR TITLE
Add hard link support

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -69,6 +69,20 @@ func writeNewSymbolicLink(fpath string, target string) error {
 	return nil
 }
 
+func writeNewHardLink(fpath string, target string) error {
+	err := os.MkdirAll(filepath.Dir(fpath), 0755)
+	if err != nil {
+		return fmt.Errorf("%s: making directory for file: %v", fpath, err)
+	}
+
+	err = os.Link(target, fpath)
+	if err != nil {
+		return fmt.Errorf("%s: making hard link for: %v", fpath, err)
+	}
+
+	return nil
+}
+
 func mkdir(dirPath string) error {
 	err := os.MkdirAll(dirPath, 0755)
 	if err != nil {

--- a/tar.go
+++ b/tar.go
@@ -151,6 +151,8 @@ func untarFile(tr *tar.Reader, header *tar.Header, destination string) error {
 		return writeNewFile(filepath.Join(destination, header.Name), tr, header.FileInfo().Mode())
 	case tar.TypeSymlink:
 		return writeNewSymbolicLink(filepath.Join(destination, header.Name), header.Linkname)
+	case tar.TypeLink:
+		return writeNewHardLink(filepath.Join(destination, header.Name), filepath.Join(destination, header.Linkname))
 	default:
 		return fmt.Errorf("%s: unknown type flag: %c", header.Name, header.Typeflag)
 	}


### PR DESCRIPTION
This was necessary for extracting [the FreeBSD base system](http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/11.0-RELEASE/base.txz).