### PR TITLE
Identify archive format from file header

### DIFF
--- a/archiver_test.go
+++ b/archiver_test.go
@@ -39,6 +39,10 @@ func symmetricTest(t *testing.T, name string, ar Archiver) {
 		t.Fatalf("making archive: didn't expect an error, but got: %v", err)
 	}
 
+	if !ar.Match(outfile) {
+		t.Fatalf("identifying format should be 'true', but got 'false'")
+	}
+
 	var expectedFileCount int
 	filepath.Walk("testdata", func(fpath string, info os.FileInfo, err error) error {
 		expectedFileCount++

--- a/tar.go
+++ b/tar.go
@@ -76,15 +76,8 @@ func hasTarHeader(buf []byte) bool {
 	if hdrSum != usum && int64(hdrSum) != sum {
 		return false // invalid checksum
 	}
-	// checksum OK
 
-	magic := buf[257:265]
-	if bytes.Equal(magic, []byte("ustar  \x00")) {
-		return true // GNU tar
-	} else if bytes.Equal(magic[:6], []byte("ustar\x00")) {
-		return true // POSIX tar
-	}
-	return true // Old style tar
+	return true
 }
 
 // Make creates a .tar file at tarPath containing the

--- a/tar.go
+++ b/tar.go
@@ -2,10 +2,12 @@ package archiver
 
 import (
 	"archive/tar"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -19,8 +21,70 @@ func init() {
 type tarFormat struct{}
 
 func (tarFormat) Match(filename string) bool {
-	// TODO: read file header to identify the format
-	return strings.HasSuffix(strings.ToLower(filename), ".tar")
+	return strings.HasSuffix(strings.ToLower(filename), ".tar") || isTar(filename)
+}
+
+const tarBlockSize int = 512
+
+// isTar checks the file has the Tar format header by reading its beginning
+// block.
+func isTar(tarPath string) bool {
+	f, err := os.Open(tarPath)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	buf := make([]byte, tarBlockSize)
+	if _, err = io.ReadFull(f, buf); err != nil {
+		return false
+	}
+
+	return hasTarHeader(buf)
+
+}
+
+// hasTarHeader checks passed bytes has a valid tar header or not. buf must
+// contain at least 512 bytes and if not, it always returns false.
+func hasTarHeader(buf []byte) bool {
+	if len(buf) < tarBlockSize {
+		return false
+	}
+
+	b := buf[148:156]
+	b = bytes.Trim(b, " \x00") // clean up all spaces and null bytes
+	if len(b) == 0 {
+		return false // unknown format
+	}
+	hdrSum, err := strconv.ParseUint(string(b), 8, 64)
+	if err != nil {
+		return false
+	}
+
+	// According to the go official archive/tar, Sun tar uses signed byte
+	// values so this calcs both signed and unsigned
+	var usum uint64
+	var sum int64
+	for i, c := range buf {
+		if 148 <= i && i < 156 {
+			c = ' ' // checksum field itself is counted as branks
+		}
+		usum += uint64(uint8(c))
+		sum += int64(int8(c))
+	}
+
+	if hdrSum != usum && int64(hdrSum) != sum {
+		return false // invalid checksum
+	}
+	// checksum OK
+
+	magic := buf[257:265]
+	if bytes.Equal(magic, []byte("ustar  \x00")) {
+		return true // GNU tar
+	} else if bytes.Equal(magic[:6], []byte("ustar\x00")) {
+		return true // POSIX tar
+	}
+	return true // Old style tar
 }
 
 // Make creates a .tar file at tarPath containing the


### PR DESCRIPTION
This adds an archive format identification by checking a file's header, which is commented as Todo in `Match` methods in each format codes. But despite this, `Match` method still prefers a file extension identification to this and uses this only when a file doesn't have an expected extension so its behavior would not change so much.

There are a few more points should be noted

- Added methods only return `bool` value, without an error value not to change `Match` method interface
- Added methods don't care if a passed `filename` is actually accessible or not and if not, they silently return `false`