### PR TITLE
tar: Add TypeChar, TypeBlock and TypeFifo header flags support

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -204,7 +204,7 @@ func untarFile(tr *tar.Reader, header *tar.Header, destination string) error {
 	switch header.Typeflag {
 	case tar.TypeDir:
 		return mkdir(filepath.Join(destination, header.Name))
-	case tar.TypeReg, tar.TypeRegA:
+	case tar.TypeReg, tar.TypeRegA, tar.TypeChar, tar.TypeBlock, tar.TypeFifo:
 		return writeNewFile(filepath.Join(destination, header.Name), tr, header.FileInfo().Mode())
 	case tar.TypeSymlink:
 		return writeNewSymbolicLink(filepath.Join(destination, header.Name), header.Linkname)


### PR DESCRIPTION
Character devices, block devices and named pipes have the separate types, but at the same time they can be extracted like the other files and they're handled well by archive/tar library. Supporting these headers is necessary for extracting Linux rootfs archives.