### PR TITLE
Zip.Make: fixed path bug in windows

### DIFF
--- a/zip.go
+++ b/zip.go
@@ -92,7 +92,11 @@ func zipFile(w *zip.Writer, source string) error {
 		}
 
 		if baseDir != "" {
-			header.Name = path.Join(baseDir, strings.TrimPrefix(fpath, source))
+			name, err := filepath.Rel(source, fpath)
+			if err != nil {
+				return err
+			}
+			header.Name = path.Join(baseDir, name)
 		}
 
 		if info.IsDir() {


### PR DESCRIPTION
In Windows, zipping a directory such as:
```
a\
  b\
    file
```

Results in an archive that looks like this:
```
a\
  b\
    \file
```

(notice how "file" is prefixed by a slah)
This is caused by the usage of strings.TrimPrefix to make a path relative. strings.TrimPrefix doesn't ensure the removal of trailing slashes and it will leave a backward trailing slash untouched. I fixed the problem by using filepath.Rel instead.

I hope this helps other folks using/deploying applications to Windows.

Thanks for this awesome library mholt ;-)