### PR TITLE
Mod:fix bug for symbolic link file while making tar

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -145,6 +145,20 @@ func tarFile(tarWriter *tar.Writer, source, dest string) error {
 			header.Name += "/"
 		}
 
+		if !info.IsDir() {
+			fi, err := os.Lstat(path)
+			if err != nil {
+				return fmt.Errorf("%s: get lstat: %v", path, err)
+			}
+			if fi.Mode()&os.ModeSymlink != 0 {
+				link, err := os.Readlink(path)
+				if err != nil {
+					return fmt.Errorf("%s: read link: %v", path, err)
+				}
+				header.Linkname = link
+			}
+		}
+		
 		err = tarWriter.WriteHeader(header)
 		if err != nil {
 			return fmt.Errorf("%s: writing header: %v", path, err)


### PR DESCRIPTION
# problem
while making a tar file, if a source file is a symbolic, then the link information is wrong, just link to the file's path.

# fix
check if a file is a symbolic link, if it is , get the link information , then write to the tar file info header