### PR TITLE
Fix zip header name with wrong sep

### DIFF
--- a/zip.go
+++ b/zip.go
@@ -96,7 +96,7 @@ func zipFile(w *zip.Writer, source string) error {
 			if err != nil {
 				return err
 			}
-			header.Name = path.Join(baseDir, name)
+			header.Name = path.Join(baseDir, filepath.ToSlash(name))
 		}
 
 		if info.IsDir() {


### PR DESCRIPTION
When compress a folder contains subdirectory to zip on windows and then uncompress on *nix, the files in subdirectory will in a flatten level. Its' unexpected.