### PR TITLE
Add support for multipart rar files

### DIFF
--- a/rar.go
+++ b/rar.go
@@ -52,16 +52,11 @@ func (rarFormat) Make(rarPath string, filePaths []string) error {
 // Open extracts the RAR file at source and puts the contents
 // into destination.
 func (rarFormat) Open(source, destination string) error {
-	f, err := os.Open(source)
-	if err != nil {
-		return fmt.Errorf("%s: failed to open archive: %v", source, err)
-	}
-	defer f.Close()
-
-	rr, err := rardecode.NewReader(f, "")
+	rr, err := rardecode.OpenReader(source, "")
 	if err != nil {
 		return fmt.Errorf("%s: failed to create reader: %v", source, err)
 	}
+	defer rr.Close()
 
 	for {
 		header, err := rr.Next()


### PR DESCRIPTION
rardecode has a method called `OpenReader` which should act the same as NewReader, but also supports multipart rar files.

This shouldn't cause any issues or undesired side effects, it just skips the `os.Open` call and passes the path directly to the rardecode package.