### PR TITLE
Add Read and Write methods to Archiver interface that accept io.Reader/io.Writer.

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -13,10 +13,14 @@ import (
 type Archiver interface {
 	// Match checks supported files
 	Match(filename string) bool
-	// Make makes an archive.
+	// Make makes an archive file on disk.
 	Make(destination string, sources []string) error
-	// Open extracts an archive.
+	// Open extracts an archive file on disk.
 	Open(source, destination string) error
+	// Write writes an archive to a Writer.
+	Write(output io.Writer, sources []string) error
+	// Read reads an archive from a Reader.
+	Read(input io.Reader, destination string) error
 }
 
 // SupportedFormats contains all supported archive formats

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -30,20 +30,20 @@ func testWriteRead(t *testing.T, name string, ar Archiver) {
 	buf := new(bytes.Buffer)
 	tmp, err := ioutil.TempDir("", "archiver")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("[%s] %v", name, err)
 	}
 	defer os.RemoveAll(tmp)
 
 	// Test creating archive
 	err = ar.Write(buf, []string{"testdata"})
 	if err != nil {
-		t.Fatalf("writing archive: didn't expect an error, but got: %v", err)
+		t.Fatalf("[%s] writing archive: didn't expect an error, but got: %v", name, err)
 	}
 
 	// Test extracting archive
 	err = ar.Read(buf, tmp)
 	if err != nil {
-		t.Fatalf("reading archive: didn't expect an error, but got: %v", err)
+		t.Fatalf("[%s] reading archive: didn't expect an error, but got: %v", name, err)
 	}
 
 	// Check that what was extracted is what was compressed
@@ -56,19 +56,19 @@ func testWriteRead(t *testing.T, name string, ar Archiver) {
 func testMakeOpen(t *testing.T, name string, ar Archiver) {
 	tmp, err := ioutil.TempDir("", "archiver")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("[%s] %v", name, err)
 	}
-	//defer os.RemoveAll(tmp)
+	defer os.RemoveAll(tmp)
 
 	// Test creating archive
 	outfile := filepath.Join(tmp, "test-"+name)
 	err = ar.Make(outfile, []string{"testdata"})
 	if err != nil {
-		t.Fatalf("making archive: didn't expect an error, but got: %v", err)
+		t.Fatalf("[%s] making archive: didn't expect an error, but got: %v", name, err)
 	}
 
 	if !ar.Match(outfile) {
-		t.Fatalf("identifying format should be 'true', but got 'false'")
+		t.Fatalf("[%s] identifying format should be 'true', but got 'false'", name)
 	}
 
 	// Test extracting archive
@@ -76,7 +76,7 @@ func testMakeOpen(t *testing.T, name string, ar Archiver) {
 	os.Mkdir(dest, 0755)
 	err = ar.Open(outfile, dest)
 	if err != nil {
-		t.Fatalf("extracting archive [%s -> %s]: didn't expect an error, but got: %v", outfile, dest, err)
+		t.Fatalf("[%s] extracting archive [%s -> %s]: didn't expect an error, but got: %v", name, outfile, dest, err)
 	}
 
 	// Check that what was extracted is what was compressed
@@ -103,14 +103,14 @@ func symmetricTest(t *testing.T, name, dest string) {
 
 		origPath, err := filepath.Rel(dest, fpath)
 		if err != nil {
-			t.Fatalf("%s: Error inducing original file path: %v", fpath, err)
+			t.Fatalf("[%s] %s: Error inducing original file path: %v", name, fpath, err)
 		}
 
 		if info.IsDir() {
 			// stat dir instead of read file
 			_, err = os.Stat(origPath)
 			if err != nil {
-				t.Fatalf("%s: Couldn't stat original directory (%s): %v",
+				t.Fatalf("[%s] %s: Couldn't stat original directory (%s): %v", name,
 					fpath, origPath, err)
 			}
 			return nil
@@ -118,36 +118,36 @@ func symmetricTest(t *testing.T, name, dest string) {
 
 		expectedFileInfo, err := os.Stat(origPath)
 		if err != nil {
-			t.Fatalf("%s: Error obtaining original file info: %v", fpath, err)
+			t.Fatalf("[%s] %s: Error obtaining original file info: %v", name, fpath, err)
 		}
 		expected, err := ioutil.ReadFile(origPath)
 		if err != nil {
-			t.Fatalf("%s: Couldn't open original file (%s) from disk: %v",
+			t.Fatalf("[%s] %s: Couldn't open original file (%s) from disk: %v", name,
 				fpath, origPath, err)
 		}
 
 		actualFileInfo, err := os.Stat(fpath)
 		if err != nil {
-			t.Fatalf("%s: Error obtaining actual file info: %v", fpath, err)
+			t.Fatalf("[%s] %s: Error obtaining actual file info: %v", name, fpath, err)
 		}
 		actual, err := ioutil.ReadFile(fpath)
 		if err != nil {
-			t.Fatalf("%s: Couldn't open new file from disk: %v", fpath, err)
+			t.Fatalf("[%s] %s: Couldn't open new file from disk: %v", name, fpath, err)
 		}
 
 		if actualFileInfo.Mode() != expectedFileInfo.Mode() {
-			t.Fatalf("%s: File mode differed between on disk and compressed",
+			t.Fatalf("[%s] %s: File mode differed between on disk and compressed", name,
 				expectedFileInfo.Mode().String()+" : "+actualFileInfo.Mode().String())
 		}
 		if !bytes.Equal(expected, actual) {
-			t.Fatalf("%s: File contents differed between on disk and compressed", origPath)
+			t.Fatalf("[%s] %s: File contents differed between on disk and compressed", name, origPath)
 		}
 
 		return nil
 	})
 
 	if got, want := actualFileCount, expectedFileCount; got != want {
-		t.Fatalf("Expected %d resulting files, got %d", want, got)
+		t.Fatalf("[%s] Expected %d resulting files, got %d", name, want, got)
 	}
 }
 

--- a/targz.go
+++ b/targz.go
@@ -1,9 +1,9 @@
 package archiver
 
 import (
-	"archive/tar"
 	"compress/gzip"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
@@ -47,6 +47,13 @@ func isTarGz(targzPath string) bool {
 	return hasTarHeader(buf)
 }
 
+// Write outputs a .tar.gz file to a Writer containing
+// the contents of files listed in filePaths. It works
+// the same way Tar does, but with gzip compression.
+func (tarGzFormat) Write(output io.Writer, filePaths []string) error {
+	return writeTarGz(filePaths, output, "")
+}
+
 // Make creates a .tar.gz file at targzPath containing
 // the contents of files listed in filePaths. It works
 // the same way Tar does, but with gzip compression.
@@ -57,13 +64,26 @@ func (tarGzFormat) Make(targzPath string, filePaths []string) error {
 	}
 	defer out.Close()
 
-	gzWriter := gzip.NewWriter(out)
-	defer gzWriter.Close()
+	return writeTarGz(filePaths, out, targzPath)
+}
 
-	tarWriter := tar.NewWriter(gzWriter)
-	defer tarWriter.Close()
+func writeTarGz(filePaths []string, output io.Writer, dest string) error {
+	gzw := gzip.NewWriter(output)
+	defer gzw.Close()
 
-	return tarball(filePaths, tarWriter, targzPath)
+	return writeTar(filePaths, gzw, dest)
+}
+
+// Read untars a .tar.gz file read from a Reader and decompresses
+// the contents into destination.
+func (tarGzFormat) Read(input io.Reader, destination string) error {
+	gzr, err := gzip.NewReader(input)
+	if err != nil {
+		return fmt.Errorf("error decompressing: %v", err)
+	}
+	defer gzr.Close()
+
+	return Tar.Read(gzr, destination)
 }
 
 // Open untars source and decompresses the contents into destination.
@@ -74,11 +94,5 @@ func (tarGzFormat) Open(source, destination string) error {
 	}
 	defer f.Close()
 
-	gzr, err := gzip.NewReader(f)
-	if err != nil {
-		return fmt.Errorf("%s: create new gzip reader: %v", source, err)
-	}
-	defer gzr.Close()
-
-	return untar(tar.NewReader(gzr), destination)
+	return TarGz.Read(f, destination)
 }

--- a/tarlz4.go
+++ b/tarlz4.go
@@ -1,8 +1,8 @@
 package archiver
 
 import (
-	"archive/tar"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -41,6 +41,15 @@ func isTarLz4(tarlz4Path string) bool {
 	return hasTarHeader(buf)
 }
 
+// Write outputs a .tar.lz4 file to a Writer containing
+// the contents of files listed in filePaths. File paths
+// can be those of regular files or directories. Regular
+// files are stored at the 'root' of the archive, and
+// directories are recursively added.
+func (tarLz4Format) Write(output io.Writer, filePaths []string) error {
+	return writeTarLz4(filePaths, output, "")
+}
+
 // Make creates a .tar.lz4 file at tarlz4Path containing
 // the contents of files listed in filePaths. File paths
 // can be those of regular files or directories. Regular
@@ -53,13 +62,22 @@ func (tarLz4Format) Make(tarlz4Path string, filePaths []string) error {
 	}
 	defer out.Close()
 
-	lz4Writer := lz4.NewWriter(out)
-	defer lz4Writer.Close()
+	return writeTarLz4(filePaths, out, tarlz4Path)
+}
 
-	tarWriter := tar.NewWriter(lz4Writer)
-	defer tarWriter.Close()
+func writeTarLz4(filePaths []string, output io.Writer, dest string) error {
+	lz4w := lz4.NewWriter(output)
+	defer lz4w.Close()
 
-	return tarball(filePaths, tarWriter, tarlz4Path)
+	return writeTar(filePaths, lz4w, dest)
+}
+
+// Read untars a .tar.xz file read from a Reader and decompresses
+// the contents into destination.
+func (tarLz4Format) Read(input io.Reader, destination string) error {
+	lz4r := lz4.NewReader(input)
+
+	return Tar.Read(lz4r, destination)
 }
 
 // Open untars source and decompresses the contents into destination.
@@ -70,6 +88,5 @@ func (tarLz4Format) Open(source, destination string) error {
 	}
 	defer f.Close()
 
-	lz4r := lz4.NewReader(f)
-	return untar(tar.NewReader(lz4r), destination)
+	return TarLz4.Read(f, destination)
 }


### PR DESCRIPTION
1. Adds methods to interface.
2. Implement methods for each format.
3. Reimplement Make/Open so that code is shared.

This intended to implement a solution to issue #20.