### PR TITLE
fix tar for relative path directory

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -13,10 +13,14 @@ import (
 type Archiver interface {
 	// Match checks supported files
 	Match(filename string) bool
-	// Make makes an archive.
+	// Make makes an archive file on disk.
 	Make(destination string, sources []string) error
-	// Open extracts an archive.
+	// Open extracts an archive file on disk.
 	Open(source, destination string) error
+	// Write writes an archive to a Writer.
+	Write(output io.Writer, sources []string) error
+	// Read reads an archive from a Reader.
+	Read(input io.Reader, destination string) error
 }
 
 // SupportedFormats contains all supported archive formats

--- a/archiver.go
+++ b/archiver.go
@@ -35,6 +35,17 @@ func RegisterFormat(name string, format Archiver) {
 	SupportedFormats[name] = format
 }
 
+// MatchingFormat returns the first archive format that matches
+// the given file, or nil if there is no match
+func MatchingFormat(fpath string) Archiver {
+	for _, fmt := range SupportedFormats {
+		if fmt.Match(fpath) {
+			return fmt
+		}
+	}
+	return nil
+}
+
 func writeNewFile(fpath string, in io.Reader, fm os.FileMode) error {
 	err := os.MkdirAll(filepath.Dir(fpath), 0755)
 	if err != nil {

--- a/cmd/archiver/main.go
+++ b/cmd/archiver/main.go
@@ -14,35 +14,32 @@ func main() {
 
 	cmd, filename := os.Args[1], os.Args[2]
 
-	for _, ff := range archiver.SupportedFormats {
-		if !ff.Match(filename) {
-			continue
-		}
-		var err error
-		switch cmd {
-		case "make":
-			if len(os.Args) < 4 {
-				fatal(usage)
-			}
-			err = ff.Make(filename, os.Args[3:])
-		case "open":
-			dest := ""
-			if len(os.Args) == 4 {
-				dest = os.Args[3]
-			} else if len(os.Args) > 4 {
-				fatal(usage)
-			}
-			err = ff.Open(filename, dest)
-		default:
-			fatal(usage)
-		}
-		if err != nil {
-			fatal(err)
-		}
-		return
+	ff := archiver.MatchingFormat(filename)
+	if ff == nil {
+		fatalf("%s: Unsupported file extension", filename)
 	}
 
-	fatalf("%s: Unsupported file extension", filename)
+	var err error
+	switch cmd {
+	case "make":
+		if len(os.Args) < 4 {
+			fatal(usage)
+		}
+		err = ff.Make(filename, os.Args[3:])
+	case "open":
+		dest := ""
+		if len(os.Args) == 4 {
+			dest = os.Args[3]
+		} else if len(os.Args) > 4 {
+			fatal(usage)
+		}
+		err = ff.Open(filename, dest)
+	default:
+		fatal(usage)
+	}
+	if err != nil {
+		fatal(err)
+	}
 }
 
 func fatal(v ...interface{}) {

--- a/tar.go
+++ b/tar.go
@@ -114,15 +114,6 @@ func writeTar(filePaths []string, output io.Writer, dest string) error {
 // writing into a file located at dest.
 func tarball(filePaths []string, tarWriter *tar.Writer, dest string) error {
 	for _, fpath := range filePaths {
-		// use abs path for all
-		if !filepath.IsAbs(fpath) {
-			var err error
-			fpath, err = filepath.Abs(fpath)
-			if err != nil {
-				return err
-			}
-		}
-		
 		err := tarFile(tarWriter, fpath, dest)
 		if err != nil {
 			return err
@@ -144,6 +135,8 @@ func tarFile(tarWriter *tar.Writer, source, dest string) error {
 		baseDir = filepath.Base(source)
 	}
 
+	// because the WakkFunc will pass the standard path under the source, so let us standard the source too.
+	source = filepath.Clean(source)
 	return filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return fmt.Errorf("error walking to %s: %v", path, err)

--- a/tar.go
+++ b/tar.go
@@ -114,6 +114,15 @@ func writeTar(filePaths []string, output io.Writer, dest string) error {
 // writing into a file located at dest.
 func tarball(filePaths []string, tarWriter *tar.Writer, dest string) error {
 	for _, fpath := range filePaths {
+		// use abs path for all
+		if !filepath.IsAbs(fpath) {
+			var err error
+			fpath, err = filepath.Abs(fpath)
+			if err != nil {
+				return err
+			}
+		}
+		
 		err := tarFile(tarWriter, fpath, dest)
 		if err != nil {
 			return err

--- a/tar_test.go
+++ b/tar_test.go
@@ -57,24 +57,6 @@ func TestTar(t *testing.T) {
 
 			// Check that what was extracted is what was compressed
 			symmetricTest(t, name, dest)
-
-			// os.RemoveAll("./result")
-			// os.Mkdir("./result", 0755)
-			// // defer os.Remove("./result")
-
-			// dst := "./result/test.tar"
-			// err = Tar.Make(dst, []string{".//testdata"})
-			// if err != nil {
-			// 	t.Fatal("make tar failed:", err.Error())
-			// }
-
-			// extraction := "./result/extraction"
-			// err = Tar.Open(dst, extraction)
-			// if err != nil {
-			// 	t.Fatal("extract tar failed:", err.Error())
-			// }
-
-			// symmetricTest(t, "Tar", extraction)
 		})
 	}
 }

--- a/tar_test.go
+++ b/tar_test.go
@@ -1,0 +1,80 @@
+package archiver
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTar(t *testing.T) {
+	abs, e := filepath.Abs("./testdata")
+	if e != nil {
+		t.Fatal("get absolute path for testdata failed:", e.Error())
+	}
+
+	testdataAllForm := []string{
+		abs,
+		abs + "/",
+		"testdata",
+		"./testdata",
+		".//testdata",
+		"./testdata/",
+		".//testdata/",
+	}
+
+	name := "Tar"
+	ar := Tar
+	for _, p := range testdataAllForm {
+		t.Run(fmt.Sprintf("path=%s", p), func(t *testing.T) {
+			t.Parallel()
+
+			tmp, err := ioutil.TempDir("", "archiver")
+			if err != nil {
+				t.Fatalf("[%s] %v", name, err)
+			}
+			defer os.RemoveAll(tmp)
+
+			// Test creating archive
+			outfile := filepath.Join(tmp, "test-"+name)
+			err = ar.Make(outfile, []string{p})
+			if err != nil {
+				t.Fatalf("[%s] making archive: didn't expect an error, but got: %v", name, err)
+			}
+
+			if !ar.Match(outfile) {
+				t.Fatalf("[%s] identifying format should be 'true', but got 'false'", name)
+			}
+
+			// Test extracting archive
+			dest := filepath.Join(tmp, "extraction_test")
+			os.Mkdir(dest, 0755)
+			err = ar.Open(outfile, dest)
+			if err != nil {
+				t.Fatalf("[%s] extracting archive [%s -> %s]: didn't expect an error, but got: %v", name, outfile, dest, err)
+			}
+
+			// Check that what was extracted is what was compressed
+			symmetricTest(t, name, dest)
+
+			// os.RemoveAll("./result")
+			// os.Mkdir("./result", 0755)
+			// // defer os.Remove("./result")
+
+			// dst := "./result/test.tar"
+			// err = Tar.Make(dst, []string{".//testdata"})
+			// if err != nil {
+			// 	t.Fatal("make tar failed:", err.Error())
+			// }
+
+			// extraction := "./result/extraction"
+			// err = Tar.Open(dst, extraction)
+			// if err != nil {
+			// 	t.Fatal("extract tar failed:", err.Error())
+			// }
+
+			// symmetricTest(t, "Tar", extraction)
+		})
+	}
+}

--- a/targz.go
+++ b/targz.go
@@ -1,9 +1,9 @@
 package archiver
 
 import (
-	"archive/tar"
 	"compress/gzip"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
@@ -47,6 +47,13 @@ func isTarGz(targzPath string) bool {
 	return hasTarHeader(buf)
 }
 
+// Write outputs a .tar.gz file to a Writer containing
+// the contents of files listed in filePaths. It works
+// the same way Tar does, but with gzip compression.
+func (tarGzFormat) Write(output io.Writer, filePaths []string) error {
+	return writeTarGz(filePaths, output, "")
+}
+
 // Make creates a .tar.gz file at targzPath containing
 // the contents of files listed in filePaths. It works
 // the same way Tar does, but with gzip compression.
@@ -57,13 +64,26 @@ func (tarGzFormat) Make(targzPath string, filePaths []string) error {
 	}
 	defer out.Close()
 
-	gzWriter := gzip.NewWriter(out)
-	defer gzWriter.Close()
+	return writeTarGz(filePaths, out, targzPath)
+}
 
-	tarWriter := tar.NewWriter(gzWriter)
-	defer tarWriter.Close()
+func writeTarGz(filePaths []string, output io.Writer, dest string) error {
+	gzw := gzip.NewWriter(output)
+	defer gzw.Close()
 
-	return tarball(filePaths, tarWriter, targzPath)
+	return writeTar(filePaths, gzw, dest)
+}
+
+// Read untars a .tar.gz file read from a Reader and decompresses
+// the contents into destination.
+func (tarGzFormat) Read(input io.Reader, destination string) error {
+	gzr, err := gzip.NewReader(input)
+	if err != nil {
+		return fmt.Errorf("error decompressing: %v", err)
+	}
+	defer gzr.Close()
+
+	return Tar.Read(gzr, destination)
 }
 
 // Open untars source and decompresses the contents into destination.
@@ -74,11 +94,5 @@ func (tarGzFormat) Open(source, destination string) error {
 	}
 	defer f.Close()
 
-	gzr, err := gzip.NewReader(f)
-	if err != nil {
-		return fmt.Errorf("%s: create new gzip reader: %v", source, err)
-	}
-	defer gzr.Close()
-
-	return untar(tar.NewReader(gzr), destination)
+	return TarGz.Read(f, destination)
 }

--- a/tarlz4.go
+++ b/tarlz4.go
@@ -1,8 +1,8 @@
 package archiver
 
 import (
-	"archive/tar"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -41,6 +41,15 @@ func isTarLz4(tarlz4Path string) bool {
 	return hasTarHeader(buf)
 }
 
+// Write outputs a .tar.lz4 file to a Writer containing
+// the contents of files listed in filePaths. File paths
+// can be those of regular files or directories. Regular
+// files are stored at the 'root' of the archive, and
+// directories are recursively added.
+func (tarLz4Format) Write(output io.Writer, filePaths []string) error {
+	return writeTarLz4(filePaths, output, "")
+}
+
 // Make creates a .tar.lz4 file at tarlz4Path containing
 // the contents of files listed in filePaths. File paths
 // can be those of regular files or directories. Regular
@@ -53,13 +62,22 @@ func (tarLz4Format) Make(tarlz4Path string, filePaths []string) error {
 	}
 	defer out.Close()
 
-	lz4Writer := lz4.NewWriter(out)
-	defer lz4Writer.Close()
+	return writeTarLz4(filePaths, out, tarlz4Path)
+}
 
-	tarWriter := tar.NewWriter(lz4Writer)
-	defer tarWriter.Close()
+func writeTarLz4(filePaths []string, output io.Writer, dest string) error {
+	lz4w := lz4.NewWriter(output)
+	defer lz4w.Close()
 
-	return tarball(filePaths, tarWriter, tarlz4Path)
+	return writeTar(filePaths, lz4w, dest)
+}
+
+// Read untars a .tar.xz file read from a Reader and decompresses
+// the contents into destination.
+func (tarLz4Format) Read(input io.Reader, destination string) error {
+	lz4r := lz4.NewReader(input)
+
+	return Tar.Read(lz4r, destination)
 }
 
 // Open untars source and decompresses the contents into destination.
@@ -70,6 +88,5 @@ func (tarLz4Format) Open(source, destination string) error {
 	}
 	defer f.Close()
 
-	lz4r := lz4.NewReader(f)
-	return untar(tar.NewReader(lz4r), destination)
+	return TarLz4.Read(f, destination)
 }


### PR DESCRIPTION
when use `Tar` to make a relative path directory, it will make one more folder with the same name wrap for the the dest folder.

for example, the folder I want to make tar is:
```
- relative_path
  - a.txt
  - b.txt
```

after I use like this:

```go
archiver.Tar.Make(tarPath, []string{"./relative_path"})
```

when I try to untar it, I get:
```
- relative_path
 - relative_path
  - a.txt
  - b.txt
```

So, I add this code to make all path for tar is abs path to fix this.