### PR TITLE
Add Functionality to Replace Illegal File and Folder Name Characters on Windows

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -27,8 +27,8 @@ type Archiver interface {
 // SupportedFormats contains all supported archive formats
 var SupportedFormats = map[string]Archiver{}
 
-// WindowsReplacer replaces invalid characters in Windows filenames with underscore
-var WindowsReplacer = strings.NewReplacer(
+// windowsReplacer replaces invalid characters in Windows filenames with underscore
+var windowsReplacer = strings.NewReplacer(
 	"<", "_",
 	">", "_",
 	":", "_",
@@ -61,7 +61,7 @@ func MatchingFormat(fpath string) Archiver {
 
 func writeNewFile(fpath string, in io.Reader, fm os.FileMode) error {
 	if runtime.GOOS == "windows" {
-		fpath = WindowsReplacer.Replace(fpath)
+		fpath = windowsReplacer.Replace(fpath)
 	}
 
 	err := os.MkdirAll(filepath.Dir(fpath), 0755)
@@ -89,8 +89,8 @@ func writeNewFile(fpath string, in io.Reader, fm os.FileMode) error {
 
 func writeNewSymbolicLink(fpath string, target string) error {
 	if runtime.GOOS == "windows" {
-		fpath = WindowsReplacer.Replace(fpath)
-		target = WindowsReplacer.Replace(target)
+		fpath = windowsReplacer.Replace(fpath)
+		target = windowsReplacer.Replace(target)
 	}
 
 	err := os.MkdirAll(filepath.Dir(fpath), 0755)
@@ -108,8 +108,8 @@ func writeNewSymbolicLink(fpath string, target string) error {
 
 func writeNewHardLink(fpath string, target string) error {
 	if runtime.GOOS == "windows" {
-		fpath = WindowsReplacer.Replace(fpath)
-		target = WindowsReplacer.Replace(target)
+		fpath = windowsReplacer.Replace(fpath)
+		target = windowsReplacer.Replace(target)
 	}
 
 	err := os.MkdirAll(filepath.Dir(fpath), 0755)
@@ -127,7 +127,7 @@ func writeNewHardLink(fpath string, target string) error {
 
 func mkdir(dirPath string) error {
 	if runtime.GOOS == "windows" {
-		dirPath = WindowsReplacer.Replace(dirPath)
+		dirPath = windowsReplacer.Replace(dirPath)
 	}
 
 	err := os.MkdirAll(dirPath, 0755)

--- a/archiver.go
+++ b/archiver.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // Archiver represent a archive format
@@ -25,6 +26,18 @@ type Archiver interface {
 
 // SupportedFormats contains all supported archive formats
 var SupportedFormats = map[string]Archiver{}
+
+// WindowsReplacer replaces invalid characters in Windows filenames with underscore
+var WindowsReplacer = strings.NewReplacer(
+	"<", "_",
+	">", "_",
+	":", "_",
+	"\"", "_",
+	"/", "_",
+	"?", "_",
+	"*", "_",
+	"|", "_",
+)
 
 // RegisterFormat adds a supported archive format
 func RegisterFormat(name string, format Archiver) {
@@ -47,6 +60,10 @@ func MatchingFormat(fpath string) Archiver {
 }
 
 func writeNewFile(fpath string, in io.Reader, fm os.FileMode) error {
+	if runtime.GOOS == "windows" {
+		fpath = WindowsReplacer.Replace(fpath)
+	}
+
 	err := os.MkdirAll(filepath.Dir(fpath), 0755)
 	if err != nil {
 		return fmt.Errorf("%s: making directory for file: %v", fpath, err)
@@ -71,6 +88,11 @@ func writeNewFile(fpath string, in io.Reader, fm os.FileMode) error {
 }
 
 func writeNewSymbolicLink(fpath string, target string) error {
+	if runtime.GOOS == "windows" {
+		fpath = WindowsReplacer.Replace(fpath)
+		target = WindowsReplacer.Replace(target)
+	}
+
 	err := os.MkdirAll(filepath.Dir(fpath), 0755)
 	if err != nil {
 		return fmt.Errorf("%s: making directory for file: %v", fpath, err)
@@ -85,6 +107,11 @@ func writeNewSymbolicLink(fpath string, target string) error {
 }
 
 func writeNewHardLink(fpath string, target string) error {
+	if runtime.GOOS == "windows" {
+		fpath = WindowsReplacer.Replace(fpath)
+		target = WindowsReplacer.Replace(target)
+	}
+
 	err := os.MkdirAll(filepath.Dir(fpath), 0755)
 	if err != nil {
 		return fmt.Errorf("%s: making directory for file: %v", fpath, err)
@@ -99,6 +126,10 @@ func writeNewHardLink(fpath string, target string) error {
 }
 
 func mkdir(dirPath string) error {
+	if runtime.GOOS == "windows" {
+		dirPath = WindowsReplacer.Replace(dirPath)
+	}
+
 	err := os.MkdirAll(dirPath, 0755)
 	if err != nil {
 		return fmt.Errorf("%s: making directory: %v", dirPath, err)


### PR DESCRIPTION
Hello,

I have recently been using this library to extract .tar.gz tarballs created on Linux systems to several client platforms.  While everything "just works" on Linux and macOS, I ran into an issue where Windows systems would not extract files or folders with illegal characters (on Windows).  In my case, it was namely the colon ( : ) character.

The error message is: ```The filename, directory name, or volume label syntax is incorrect.```

Screenshot of this behavior:

![invalid_filename](https://user-images.githubusercontent.com/1161633/35476139-00878190-0360-11e8-8eb1-08fab48d4b60.png)

After making the attached changes, which replace these illegal (on Windows) characters with underscore ( _ ), my Go program can now successfully extract these tarballs.

I'm not completely certain this is the "best" approach to this issue, as it assumes everyone wants the underscore as the replacement, and it incurs a performance penalty running the strings' "Replacer" method.  However, I figured I'd leave it here in case it helps the maintainers or anyone else.

Thanks for the great library.

- Jeremy