### PR TITLE
[WIP]Fix compressing tarball on Windows

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -146,7 +146,7 @@ func tarFile(tarWriter *tar.Writer, source, dest string) error {
 		}
 
 		if baseDir != "" {
-			header.Name = filepath.Join(baseDir, strings.TrimPrefix(path, source))
+			header.Name = filepath.Join(baseDir, filepath.ToSlash(strings.TrimPrefix(path, source)))
 		}
 
 		if header.Name == dest {


### PR DESCRIPTION
Regards to tar spec, name in header should contains only slash

Fix https://github.com/mholt/archiver/issues/62

From http://www.gnu.org/software/tar/manual/html_node/Standard.html
> The name field is the file name of the file, with directory names (if any) preceding the file name, separated by slashes.

Need test.