### PR TITLE
fix: prevent extraction of archived files outside target path

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // Archiver represent a archive format
@@ -102,6 +103,17 @@ func mkdir(dirPath string) error {
 	err := os.MkdirAll(dirPath, 0755)
 	if err != nil {
 		return fmt.Errorf("%s: making directory: %v", dirPath, err)
+	}
+	return nil
+}
+
+func sanitizeExtractPath(filePath string, destination string) error {
+	// to avoid zip slip (writing outside of the destination), we resolve
+	// the target path, and make sure it's nested in the intended
+	// destination, or bail otherwise.
+	destpath := filepath.Join(destination, filePath)
+	if !strings.HasPrefix(destpath, destination) {
+		return fmt.Errorf("%s: illegal file path", filePath)
 	}
 	return nil
 }

--- a/cmd/archiver/main.go
+++ b/cmd/archiver/main.go
@@ -27,7 +27,10 @@ func main() {
 		}
 		err = ff.Make(filename, os.Args[3:])
 	case "open":
-		dest := ""
+		dest, osErr := os.Getwd()
+		if osErr != nil {
+			fatal(err)
+		}
 		if len(os.Args) == 4 {
 			dest = os.Args[3]
 		} else if len(os.Args) > 4 {

--- a/rar.go
+++ b/rar.go
@@ -72,13 +72,12 @@ func (rarFormat) Read(input io.Reader, destination string) error {
 			return err
 		}
 
-		// to avoid zip slip (writing outside of the destination), we
-		// resolve the target path, and make sure it's nested in
-		// the intended destination, or bail otherwise.
-		destpath := filepath.Join(destination, header.Name)
-		if !strings.HasPrefix(destpath, destination) {
-			return fmt.Errorf("%s: illegal file path", header.Name)
+		err = sanitizeExtractPath(header.Name, destination)
+		if err != nil {
+			return err
 		}
+
+		destpath := filepath.Join(destination, header.Name)
 
 		if header.IsDir {
 			err = mkdir(destpath)

--- a/tar.go
+++ b/tar.go
@@ -219,13 +219,12 @@ func untar(tr *tar.Reader, destination string) error {
 
 // untarFile untars a single file from tr with header header into destination.
 func untarFile(tr *tar.Reader, header *tar.Header, destination string) error {
-	// to avoid zip slip (writing outside of the destination), we resolve
-	// the target path, and make sure it's nested in the intended
-	// destination, or bail otherwise.
-	destpath := filepath.Join(destination, header.Name)
-	if !strings.HasPrefix(destpath, destination) {
-		return fmt.Errorf("%s: illegal file path", header.Name)
+	err := sanitizeExtractPath(header.Name, destination)
+	if err != nil {
+		return err
 	}
+
+	destpath := filepath.Join(destination, header.Name)
 
 	switch header.Typeflag {
 	case tar.TypeDir:

--- a/tar.go
+++ b/tar.go
@@ -219,15 +219,23 @@ func untar(tr *tar.Reader, destination string) error {
 
 // untarFile untars a single file from tr with header header into destination.
 func untarFile(tr *tar.Reader, header *tar.Header, destination string) error {
+	// to avoid zip slip (writing outside of the destination), we resolve
+	// the target path, and make sure it's nested in the intended
+	// destination, or bail otherwise.
+	destpath := filepath.Join(destination, header.Name)
+	if !strings.HasPrefix(destpath, destination) {
+		return fmt.Errorf("%s: illegal file path", header.Name)
+	}
+
 	switch header.Typeflag {
 	case tar.TypeDir:
-		return mkdir(filepath.Join(destination, header.Name))
+		return mkdir(destpath)
 	case tar.TypeReg, tar.TypeRegA, tar.TypeChar, tar.TypeBlock, tar.TypeFifo:
-		return writeNewFile(filepath.Join(destination, header.Name), tr, header.FileInfo().Mode())
+		return writeNewFile(destpath, tr, header.FileInfo().Mode())
 	case tar.TypeSymlink:
-		return writeNewSymbolicLink(filepath.Join(destination, header.Name), header.Linkname)
+		return writeNewSymbolicLink(destpath, header.Linkname)
 	case tar.TypeLink:
-		return writeNewHardLink(filepath.Join(destination, header.Name), filepath.Join(destination, header.Linkname))
+		return writeNewHardLink(destpath, filepath.Join(destination, header.Linkname))
 	default:
 		return fmt.Errorf("%s: unknown type flag: %c", header.Name, header.Typeflag)
 	}

--- a/zip.go
+++ b/zip.go
@@ -187,15 +187,13 @@ func unzipAll(r *zip.Reader, destination string) error {
 }
 
 func unzipFile(zf *zip.File, destination string) error {
-	// to avoid zip slip (writing outside of the destination), we resolve
-	// the target path, and make sure it's nested in the intended
-	// destination, or bail otherwise.
-	destpath := filepath.Join(destination, zf.Name)
-	if !strings.HasPrefix(destpath, destination) {
-		return fmt.Errorf("%s: illegal file path", zf.Name)
+	err := sanitizeExtractPath(zf.Name, destination)
+	if err != nil {
+		return err
 	}
+
 	if strings.HasSuffix(zf.Name, "/") {
-		return mkdir(destpath)
+		return mkdir(filepath.Join(destination, zf.Name))
 	}
 
 	rc, err := zf.Open()
@@ -204,7 +202,7 @@ func unzipFile(zf *zip.File, destination string) error {
 	}
 	defer rc.Close()
 
-	return writeNewFile(destpath, rc, zf.FileInfo().Mode())
+	return writeNewFile(filepath.Join(destination, zf.Name), rc, zf.FileInfo().Mode())
 }
 
 // compressedFormats is a (non-exhaustive) set of lowercased


### PR DESCRIPTION
## Why this PR?

This PR is meant to fix an arbitrary file write vulnerability, that can be achieved using a specially crafted zip archive, that holds path traversal filenames. When the filename gets concatenated to the target extraction directory, the final path ends up outside of the target folder. 

A sample malicious zip file named zip-slip.zip. (see [this gist](https://gist.github.com/grnd/2992cc4d968386ae277123bad9e7f00a)) was used, and when running the code below, resulted in creation of `evil.txt` file in /tmp folder.

```go
package main

import "log"
import "github.com/mholt/archiver"

func main() {
	err := archiver.Tar.Open("/tmp/evil-tar.tar", "/tmp/safe")
	if err != nil {
		log.Fatal(err)
	}
}
```

There are various possible ways to avoid this issue, some include checking for `..` (dot dot) characters in the filename, but the best solution in our opinion is to check if the final target filename, starts with the target folder (after both are resolved to their absolute path).

Stay secure,
Snyk Team