### PR TITLE
This commit effectively ignores PAX Header

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -235,6 +235,8 @@ func untarFile(tr *tar.Reader, header *tar.Header, destination string) error {
 		return writeNewSymbolicLink(destpath, header.Linkname)
 	case tar.TypeLink:
 		return writeNewHardLink(destpath, filepath.Join(destination, header.Linkname))
+	case tar.TypeXGlobalHeader:
+		return nil
 	default:
 		return fmt.Errorf("%s: unknown type flag: %c", header.Name, header.Typeflag)
 	}


### PR DESCRIPTION
From #27 this will ignore the PAX Header. I ran `go test` but not sure if there are additional tests to run? Locally this did fix my issue of being able to untar a tarball from github.