### PR TITLE
Add back support for multipart rar files

### DIFF
--- a/rar.go
+++ b/rar.go
@@ -64,6 +64,22 @@ func (rarFormat) Read(input io.Reader, destination string) error {
 		return fmt.Errorf("read: failed to create reader: %v", err)
 	}
 
+	return extract(rr, destination)
+}
+
+// Open extracts the RAR file at source and puts the contents
+// into destination.
+func (rarFormat) Open(source, destination string) error {
+	rf, err := rardecode.OpenReader(source, "")
+	if err != nil {
+		return fmt.Errorf("%s: failed to open file: %v", source, err)
+	}
+	defer rf.Close()
+
+	return extract(&rf.Reader, destination)
+}
+
+func extract(rr *rardecode.Reader, destination string) error {
 	for {
 		header, err := rr.Next()
 		if err == io.EOF {
@@ -101,16 +117,4 @@ func (rarFormat) Read(input io.Reader, destination string) error {
 	}
 
 	return nil
-}
-
-// Open extracts the RAR file at source and puts the contents
-// into destination.
-func (rarFormat) Open(source, destination string) error {
-	rf, err := os.Open(source)
-	if err != nil {
-		return fmt.Errorf("%s: failed to open file: %v", source, err)
-	}
-	defer rf.Close()
-
-	return Rar.Read(rf, destination)
 }


### PR DESCRIPTION
#43 broke the support for multi-part rar files that was added in #38 (due to `rardecode.OpenReader()` not being used anymore). This PR fixes that!