### PR TITLE
Ignore the pax global header from git generated tarballs

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -235,6 +235,9 @@ func untarFile(tr *tar.Reader, header *tar.Header, destination string) error {
 		return writeNewSymbolicLink(destpath, header.Linkname)
 	case tar.TypeLink:
 		return writeNewHardLink(destpath, filepath.Join(destination, header.Linkname))
+	case tar.TypeXGlobalHeader:
+		// ignore the pax global header from git generated tarballs
+		return nil
 	default:
 		return fmt.Errorf("%s: unknown type flag: %c", header.Name, header.Typeflag)
 	}


### PR DESCRIPTION
Due to inactivity on https://github.com/mholt/archiver/pull/66
Closes https://github.com/mholt/archiver/issues/27
Satisfies https://github.com/mholt/archiver/pull/66#issuecomment-398922536 (tests not necessary)

Signed-off-by: Nikki Attea <nikki@sensu.io>