### PR TITLE
Fix setting tar FileInfoHeader name

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -146,7 +146,7 @@ func tarFile(tarWriter *tar.Writer, source, dest string) error {
 		}
 
 		if baseDir != "" {
-			header.Name = filepath.Join(baseDir, strings.TrimPrefix(path, source))
+			header.Name = filepath.ToSlash(filepath.Join(baseDir, strings.TrimPrefix(path, source)))
 		}
 
 		if header.Name == dest {


### PR DESCRIPTION
I have stumbled onto issue similar to this #62, while creating tar archive on Windows and trying to build Docker (Linux based) image of it. I have found this PR #64 and adjusted the changes.

Seems like it fixed the issue.