### PR TITLE
Add support for storing symlinks in tar and zip archives

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+# set git config to clone with symlinks enabled on windows
+init:
+  - git config --global core.symlinks true
+
 version: "{build}"
 
 clone_folder: c:\gopath\src\github.com\mholt\archiver

--- a/archiver.go
+++ b/archiver.go
@@ -252,12 +252,10 @@ func writeNewSymbolicLink(fpath string, target string) error {
 	if err != nil {
 		return fmt.Errorf("%s: making directory for file: %v", fpath, err)
 	}
-
 	err = os.Symlink(target, fpath)
 	if err != nil {
 		return fmt.Errorf("%s: making symbolic link for: %v", fpath, err)
 	}
-
 	return nil
 }
 
@@ -266,13 +264,15 @@ func writeNewHardLink(fpath string, target string) error {
 	if err != nil {
 		return fmt.Errorf("%s: making directory for file: %v", fpath, err)
 	}
-
 	err = os.Link(target, fpath)
 	if err != nil {
 		return fmt.Errorf("%s: making hard link for: %v", fpath, err)
 	}
-
 	return nil
+}
+
+func isSymlink(fi os.FileInfo) bool {
+	return fi.Mode()&os.ModeSymlink != 0
 }
 
 // within returns true if sub is within or equal to parent.

--- a/tar.go
+++ b/tar.go
@@ -340,16 +340,16 @@ func (t *Tar) Write(f File) error {
 		return fmt.Errorf("missing file name")
 	}
 
-	filename := f.Name()
+	var linkTarget string
 	if isSymlink(f) {
 		var err error
-		filename, err = os.Readlink(f.Name())
+		linkTarget, err = os.Readlink(f.Name())
 		if err != nil {
 			return fmt.Errorf("%s: readlink: %v", f.Name(), err)
 		}
 	}
 
-	hdr, err := tar.FileInfoHeader(f, filepath.ToSlash(filename))
+	hdr, err := tar.FileInfoHeader(f, filepath.ToSlash(linkTarget))
 	if err != nil {
 		return fmt.Errorf("%s: making header: %v", f.Name(), err)
 	}

--- a/tar.go
+++ b/tar.go
@@ -340,15 +340,16 @@ func (t *Tar) Write(f File) error {
 		return fmt.Errorf("missing file name")
 	}
 
-	var linkTarget string
-	if (f.Mode() & os.ModeSymlink) != 0 {
+	filename := f.Name()
+	if isSymlink(f) {
 		var err error
-		linkTarget, err = os.Readlink(f.Name())
+		filename, err = os.Readlink(f.Name())
 		if err != nil {
 			return fmt.Errorf("%s: readlink: %v", f.Name(), err)
 		}
 	}
-	hdr, err := tar.FileInfoHeader(f, filepath.ToSlash(linkTarget))
+
+	hdr, err := tar.FileInfoHeader(f, filepath.ToSlash(filename))
 	if err != nil {
 		return fmt.Errorf("%s: making header: %v", f.Name(), err)
 	}
@@ -359,7 +360,7 @@ func (t *Tar) Write(f File) error {
 	}
 
 	if f.IsDir() {
-		return nil
+		return nil // directories have no contents
 	}
 
 	if hdr.Typeflag == tar.TypeReg {

--- a/testdata/exist
+++ b/testdata/exist
@@ -1,0 +1,1 @@
+/target/does/not/exist

--- a/testdata/proverb3.txt
+++ b/testdata/proverb3.txt
@@ -1,0 +1,1 @@
+proverbs/extra/proverb3.txt

--- a/zip.go
+++ b/zip.go
@@ -329,11 +329,8 @@ func (z *Zip) Write(f File) error {
 		return fmt.Errorf("%s: making header: %v", f.Name(), err)
 	}
 
-	if f.IsDir() {
-		return nil
-	}
-
-	if (header.Mode() & os.ModeSymlink) != 0 {
+	switch header.Mode() & os.ModeType {
+	case os.ModeSymlink:
 		linkTarget, err := os.Readlink(f.Name())
 		if err != nil {
 			return fmt.Errorf("%s: readlink: %v", f.Name(), err)
@@ -342,10 +339,7 @@ func (z *Zip) Write(f File) error {
 		if err != nil {
 			return fmt.Errorf("%s: writing symlink target: %v", f.Name(), err)
 		}
-		return nil
-	}
-
-	if header.Mode().IsRegular() {
+	case 0: // regular file
 		if f.ReadCloser == nil {
 			return fmt.Errorf("%s: no way to read file contents", f.Name())
 		}


### PR DESCRIPTION
Also implement extraction of symlinks from zip archives.

This PR also adds a relative symlink in the testdata directory. It passes all tests on OS X, but has not been tested on Windows.

This PR is a superset of changes from the following issues and PRs:

Fixes #21 
Fixes #31 
Fixes #60 
Fixes #74 
