### PR TITLE
Implement CheckExt(string) error for Archiver interface

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -13,12 +13,18 @@ import (
 // Archiver is a type that can create an archive file
 // from a list of source file names.
 type Archiver interface {
+	ExtensionChecker
+
 	// Archive adds all the files or folders in sources
 	// to an archive to be created at destination. Files
 	// are added to the root of the archive, and directories
 	// are walked and recursively added, preserving folder
 	// structure.
 	Archive(sources []string, destination string) error
+}
+
+// ExtensionChecker validates file extensions
+type ExtensionChecker interface {
 	CheckExt(name string) error
 }
 
@@ -110,8 +116,9 @@ var ErrStopWalk = fmt.Errorf("walk stopped")
 // Compressor compresses to out what it reads from in.
 // It also ensures a compatible or matching file extension.
 type Compressor interface {
+	ExtensionChecker
+
 	Compress(in io.Reader, out io.Writer) error
-	CheckExt(filename string) error
 }
 
 // Decompressor decompresses to out what it reads from in.

--- a/archiver.go
+++ b/archiver.go
@@ -19,6 +19,7 @@ type Archiver interface {
 	// are walked and recursively added, preserving folder
 	// structure.
 	Archive(sources []string, destination string) error
+	CheckExt(name string) error
 }
 
 // Unarchiver is a type that can extract archive files

--- a/tar.go
+++ b/tar.go
@@ -53,13 +53,22 @@ type Tar struct {
 	cleanupWrapFn func()
 }
 
+// CheckExt ensures the file extension matches the format.
+func (*Tar) CheckExt(filename string) error {
+	if !strings.HasSuffix(filename, ".tar") {
+		return fmt.Errorf("filename must have a .tar extension")
+	}
+	return nil
+}
+
 // Archive creates a tarball file at destination containing
 // the files listed in sources. The destination must end with
 // ".tar". File paths can be those of regular files or
 // directories; directories will be recursively added.
 func (t *Tar) Archive(sources []string, destination string) error {
-	if t.writerWrapFn == nil && !strings.HasSuffix(destination, ".tar") {
-		return fmt.Errorf("output filename must have .tar extension")
+	err := t.CheckExt(destination)
+	if t.writerWrapFn == nil && err != nil {
+		return fmt.Errorf("output %s", err.Error())
 	}
 	if !t.OverwriteExisting && fileExists(destination) {
 		return fmt.Errorf("file already exists: %s", destination)

--- a/tarbz2.go
+++ b/tarbz2.go
@@ -17,15 +17,24 @@ type TarBz2 struct {
 	CompressionLevel int
 }
 
+// CheckExt ensures the file extension matches the format.
+func (*TarBz2) CheckExt(filename string) error {
+	if !strings.HasSuffix(filename, ".tar.bz2") &&
+		!strings.HasSuffix(filename, ".tbz2") {
+		return fmt.Errorf("filename must have a .tar.bz2 or .tbz2 extension")
+	}
+	return nil
+}
+
 // Archive creates a compressed tar file at destination
 // containing the files listed in sources. The destination
 // must end with ".tar.bz2" or ".tbz2". File paths can be
 // those of regular files or directories; directories will
 // be recursively added.
 func (tbz2 *TarBz2) Archive(sources []string, destination string) error {
-	if !strings.HasSuffix(destination, ".tar.bz2") &&
-		!strings.HasSuffix(destination, ".tbz2") {
-		return fmt.Errorf("output filename must have .tar.bz2 or .tbz2 extension")
+	err := tbz2.CheckExt(destination)
+	if err != nil {
+		return fmt.Errorf("output %s", err.Error())
 	}
 	tbz2.wrapWriter()
 	return tbz2.Tar.Archive(sources, destination)

--- a/targz.go
+++ b/targz.go
@@ -17,15 +17,24 @@ type TarGz struct {
 	CompressionLevel int
 }
 
+// CheckExt ensures the file extension matches the format.
+func (*TarGz) CheckExt(filename string) error {
+	if !strings.HasSuffix(filename, ".tar.gz") &&
+		!strings.HasSuffix(filename, ".tgz") {
+		return fmt.Errorf("filename must have a .tar.gz or .tgz extension")
+	}
+	return nil
+}
+
 // Archive creates a compressed tar file at destination
 // containing the files listed in sources. The destination
 // must end with ".tar.gz" or ".tgz". File paths can be
 // those of regular files or directories; directories will
 // be recursively added.
 func (tgz *TarGz) Archive(sources []string, destination string) error {
-	if !strings.HasSuffix(destination, ".tar.gz") &&
-		!strings.HasSuffix(destination, ".tgz") {
-		return fmt.Errorf("output filename must have .tar.gz or .tgz extension")
+	err := tgz.CheckExt(destination)
+	if err != nil {
+		return fmt.Errorf("output %s", err.Error())
 	}
 	tgz.wrapWriter()
 	return tgz.Tar.Archive(sources, destination)

--- a/tarlz4.go
+++ b/tarlz4.go
@@ -20,15 +20,25 @@ type TarLz4 struct {
 	CompressionLevel int
 }
 
+// CheckExt ensures the file extension matches the format.
+func (*TarLz4) CheckExt(filename string) error {
+	if !strings.HasSuffix(filename, ".tar.lz4") &&
+		!strings.HasSuffix(filename, ".tlz4") {
+
+		return fmt.Errorf("filename must have a .tar.lz4 or .tlz4 extension")
+	}
+	return nil
+}
+
 // Archive creates a compressed tar file at destination
 // containing the files listed in sources. The destination
 // must end with ".tar.lz4" or ".tlz4". File paths can be
 // those of regular files or directories; directories will
 // be recursively added.
 func (tlz4 *TarLz4) Archive(sources []string, destination string) error {
-	if !strings.HasSuffix(destination, ".tar.lz4") &&
-		!strings.HasSuffix(destination, ".tlz4") {
-		return fmt.Errorf("output filename must have .tar.lz4 or .tlz4 extension")
+	err := tlz4.CheckExt(destination)
+	if err != nil {
+		return fmt.Errorf("output %s", err.Error())
 	}
 	tlz4.wrapWriter()
 	return tlz4.Tar.Archive(sources, destination)

--- a/tarsz.go
+++ b/tarsz.go
@@ -15,15 +15,24 @@ type TarSz struct {
 	*Tar
 }
 
+// CheckExt ensures the file extension matches the format.
+func (*TarSz) CheckExt(filename string) error {
+	if !strings.HasSuffix(filename, ".tar.sz") &&
+		!strings.HasSuffix(filename, ".tsz") {
+		return fmt.Errorf("filename must have a .tar.sz or .tsz extension")
+	}
+	return nil
+}
+
 // Archive creates a compressed tar file at destination
 // containing the files listed in sources. The destination
 // must end with ".tar.sz" or ".tsz". File paths can be
 // those of regular files or directories; directories will
 // be recursively added.
 func (tsz *TarSz) Archive(sources []string, destination string) error {
-	if !strings.HasSuffix(destination, ".tar.sz") &&
-		!strings.HasSuffix(destination, ".tsz") {
-		return fmt.Errorf("output filename must have .tar.sz or .tsz extension")
+	err := tsz.CheckExt(destination)
+	if err != nil {
+		return fmt.Errorf("output %s", err.Error())
 	}
 	tsz.wrapWriter()
 	return tsz.Tar.Archive(sources, destination)

--- a/tarxz.go
+++ b/tarxz.go
@@ -16,15 +16,24 @@ type TarXz struct {
 	*Tar
 }
 
+// CheckExt ensures the file extension matches the format.
+func (*TarXz) CheckExt(filename string) error {
+	if !strings.HasSuffix(filename, ".tar.xz") &&
+		!strings.HasSuffix(filename, ".txz") {
+		return fmt.Errorf("filename must have a .tar.xz or .txz extension")
+	}
+	return nil
+}
+
 // Archive creates a compressed tar file at destination
 // containing the files listed in sources. The destination
-// must end with ".tar.gz" or ".txz". File paths can be
+// must end with ".tar.xz" or ".txz". File paths can be
 // those of regular files or directories; directories will
 // be recursively added.
 func (txz *TarXz) Archive(sources []string, destination string) error {
-	if !strings.HasSuffix(destination, ".tar.xz") &&
-		!strings.HasSuffix(destination, ".txz") {
-		return fmt.Errorf("output filename must have .tar.xz or .txz extension")
+	err := txz.CheckExt(destination)
+	if err != nil {
+		return fmt.Errorf("output %s", err.Error())
 	}
 	txz.wrapWriter()
 	return txz.Tar.Archive(sources, destination)

--- a/zip.go
+++ b/zip.go
@@ -60,14 +60,23 @@ type Zip struct {
 	ridx int
 }
 
+// CheckExt ensures the file extension matches the format.
+func (*Zip) CheckExt(filename string) error {
+	if !strings.HasSuffix(filename, ".zip") {
+		return fmt.Errorf("filename must have a .zip extension")
+	}
+	return nil
+}
+
 // Archive creates a .zip file at destination containing
 // the files listed in sources. The destination must end
 // with ".zip". File paths can be those of regular files
 // or directories. Regular files are stored at the 'root'
 // of the archive, and directories are recursively added.
 func (z *Zip) Archive(sources []string, destination string) error {
-	if !strings.HasSuffix(destination, ".zip") {
-		return fmt.Errorf("output filename must have .zip extension")
+	err := z.CheckExt(destination)
+	if err != nil {
+		return fmt.Errorf("output %s", err.Error())
 	}
 	if !z.OverwriteExisting && fileExists(destination) {
 		return fmt.Errorf("file already exists: %s", destination)


### PR DESCRIPTION
There is no functional difference for existing code, only the additional function `Archiver.CheckExt(string) error` which can be used to validate file extensions for Archiver interface types.

As for stylistic choices, I wasn't too sure whether I should return the error immediately, wrap it (like I have done) or create a new error. The implementation I chose retains the original functionality whilst also matching the `CheckExt(string) error` return values in the `Compressor` interface. It's fortunate that the error strings are formatted to let me do it like this.

Also I was worried about a name-clash causing confusion/compile errors with the `Compressor.CheckExt(string) error` function, so let me know if you think I should change it.