### PR TITLE
Use canonical URL for golint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 
 install:
   - go get -t ./...
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - go get github.com/gordonklaus/ineffassign
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ stack: go 1.11
 
 install:
   - go get ./...
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - go get github.com/gordonklaus/ineffassign
   - set PATH=%GOPATH%\bin;%PATH%
 


### PR DESCRIPTION
The old URL will start breaking when the import path is being enforced in Go 1.12+

https://github.com/golang/lint/commit/c67002cb31c3a748b7688c27f20d8358b4193582