### PR TITLE
remove probable existing symbolic link

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -305,10 +305,13 @@ func writeNewFile(fpath string, in io.Reader, fm os.FileMode) error {
 	return nil
 }
 
-func writeNewSymbolicLink(fpath string, target string) error {
+func writeNewSymbolicLink(fpath string, target string, overwriteExisting bool) error {
 	err := os.MkdirAll(filepath.Dir(fpath), 0755)
 	if err != nil {
 		return fmt.Errorf("%s: making directory for file: %v", fpath, err)
+	}
+	if overwriteExisting {
+		_ = os.Remove(fpath)
 	}
 	err = os.Symlink(target, fpath)
 	if err != nil {

--- a/tar.go
+++ b/tar.go
@@ -235,7 +235,7 @@ func (t *Tar) untarFile(f File, to string) error {
 	case tar.TypeReg, tar.TypeRegA, tar.TypeChar, tar.TypeBlock, tar.TypeFifo:
 		return writeNewFile(to, f, f.Mode())
 	case tar.TypeSymlink:
-		return writeNewSymbolicLink(to, hdr.Linkname)
+		return writeNewSymbolicLink(to, hdr.Linkname, t.OverwriteExisting)
 	case tar.TypeLink:
 		return writeNewHardLink(to, filepath.Join(to, hdr.Linkname))
 	case tar.TypeXGlobalHeader:

--- a/zip.go
+++ b/zip.go
@@ -211,7 +211,7 @@ func (z *Zip) extractFile(f File, to string) error {
 		if err != nil {
 			return fmt.Errorf("%s: reading symlink target: %v", header.Name, err)
 		}
-		return writeNewSymbolicLink(to, strings.TrimSpace(buf.String()))
+		return writeNewSymbolicLink(to, strings.TrimSpace(buf.String()), z.OverwriteExisting)
 	}
 
 	return writeNewFile(to, f, f.Mode())


### PR DESCRIPTION
On some extracting situations that an archive contains a symbolic link file,
archiver tries to create a symbolic link, but already the symbolic file
exists and it causes the `file exists` error. This commit adds a blind
removing try: if the symbolic link already exists (from extraction process),
remove it and if does not, ignore the returned error.