### PR TITLE
Improved Close() error handling, updated zstd library, and zstd codec options exposed.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dsnet/compress v0.0.1
 	github.com/golang/snappy v0.0.1
 	github.com/google/go-cmp v0.3.0 // indirect
-	github.com/klauspost/compress v1.7.4
+	github.com/klauspost/compress v1.8.6
 	github.com/klauspost/pgzip v1.2.1
 	github.com/nwaples/rardecode v1.0.0
 	github.com/pierrec/lz4 v2.0.5+incompatible

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/klauspost/compress v1.7.1 h1:VRD0WLa8rweLB7alA5WMSVkoAtrI8xou5RrNd4JU
 github.com/klauspost/compress v1.7.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.7.4 h1:4UqAIzZ1Ns2epCTyJ1d2xMWvxtX+FNSCYWeOFogK9nc=
 github.com/klauspost/compress v1.7.4/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.8.6 h1:970MQcQdxX7hfgc/aqmB4a3grW0ivUVV6i1TLkP8CiE=
+github.com/klauspost/compress v1.8.6/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/cpuid v1.2.0 h1:NMpwD2G9JSFOE1/TJjGSo5zG7Yb2bTe7eq1jH+irmeE=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/pgzip v1.2.1 h1:oIPZROsWuPHpOdMVWLuJZXwgjhrW8r1yEX8UqMyeNHM=

--- a/tarbrotli.go
+++ b/tarbrotli.go
@@ -79,8 +79,8 @@ func (tbr *TarBrotli) wrapWriter() {
 		brw = brotli.NewWriterLevel(w, tbr.Quality)
 		return brw, nil
 	}
-	tbr.Tar.cleanupWrapFn = func() {
-		brw.Close()
+	tbr.Tar.cleanupWrapFn = func() error {
+		return brw.Close()
 	}
 }
 

--- a/tarbz2.go
+++ b/tarbz2.go
@@ -85,8 +85,8 @@ func (tbz2 *TarBz2) wrapWriter() {
 		})
 		return bz2w, err
 	}
-	tbz2.Tar.cleanupWrapFn = func() {
-		bz2w.Close()
+	tbz2.Tar.cleanupWrapFn = func() error {
+		return bz2w.Close()
 	}
 }
 
@@ -97,8 +97,8 @@ func (tbz2 *TarBz2) wrapReader() {
 		bz2r, err = bzip2.NewReader(r, nil)
 		return bz2r, err
 	}
-	tbz2.Tar.cleanupWrapFn = func() {
-		bz2r.Close()
+	tbz2.Tar.cleanupWrapFn = func() error {
+		return bz2r.Close()
 	}
 }
 

--- a/targz.go
+++ b/targz.go
@@ -92,8 +92,8 @@ func (tgz *TarGz) wrapWriter() {
 		}
 		return gzw, err
 	}
-	tgz.Tar.cleanupWrapFn = func() {
-		gzw.Close()
+	tgz.Tar.cleanupWrapFn = func() error {
+		return gzw.Close()
 	}
 }
 
@@ -108,8 +108,8 @@ func (tgz *TarGz) wrapReader() {
 		}
 		return gzr, err
 	}
-	tgz.Tar.cleanupWrapFn = func() {
-		gzr.Close()
+	tgz.Tar.cleanupWrapFn = func() error {
+		return gzr.Close()
 	}
 }
 

--- a/tarlz4.go
+++ b/tarlz4.go
@@ -87,8 +87,8 @@ func (tlz4 *TarLz4) wrapWriter() {
 		lz4w.Header.CompressionLevel = tlz4.CompressionLevel
 		return lz4w, nil
 	}
-	tlz4.Tar.cleanupWrapFn = func() {
-		lz4w.Close()
+	tlz4.Tar.cleanupWrapFn = func() error {
+		return lz4w.Close()
 	}
 }
 

--- a/tarsz.go
+++ b/tarsz.go
@@ -80,8 +80,8 @@ func (tsz *TarSz) wrapWriter() {
 		sw = snappy.NewWriter(w)
 		return sw, nil
 	}
-	tsz.Tar.cleanupWrapFn = func() {
-		sw.Close()
+	tsz.Tar.cleanupWrapFn = func() error {
+		return sw.Close()
 	}
 }
 

--- a/tarxz.go
+++ b/tarxz.go
@@ -82,8 +82,8 @@ func (txz *TarXz) wrapWriter() {
 		xzw, err = xz.NewWriter(w)
 		return xzw, err
 	}
-	txz.Tar.cleanupWrapFn = func() {
-		xzw.Close()
+	txz.Tar.cleanupWrapFn = func() error {
+		return xzw.Close()
 	}
 }
 

--- a/tarzst.go
+++ b/tarzst.go
@@ -92,8 +92,8 @@ func (tzst *TarZstd) wrapWriter() {
 		zstdw, err = zstd.NewWriter(w, tzst.eopts...)
 		return zstdw, err
 	}
-	tzst.Tar.cleanupWrapFn = func() {
-		zstdw.Close()
+	tzst.Tar.cleanupWrapFn = func() error {
+		return zstdw.Close()
 	}
 }
 
@@ -104,8 +104,9 @@ func (tzst *TarZstd) wrapReader() {
 		zstdr, err = zstd.NewReader(r, tzst.dopts...)
 		return zstdr, err
 	}
-	tzst.Tar.cleanupWrapFn = func() {
+	tzst.Tar.cleanupWrapFn = func() error {
 		zstdr.Close()
+		return nil
 	}
 }
 


### PR DESCRIPTION
The updated zstd library brings perf optimization, memory consumption optimizations, as well as better detection of certain corrupt archives (which we've hit).

Each commit is isolated and could be cherry-picked separately.  Here's a summary of each commit:

    Boost zstd library to version `1.8.6` which brings optimizations in terms
    of speed and memory use.


    Added support to set encoder and decoder options for zstd, necessary
    for some archive sizes (regarding memory usage).


    Fixes #184: handle errors coming out of (most) `Close()` statements that
    return errors.