### PR TITLE
Add ReaderUnarchiver interface and provide implementations

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -78,6 +78,12 @@ type Unarchiver interface {
 	Unarchive(source, destination string) error
 }
 
+// ReaderUnarchiver is a type that can extract archive files
+// from an io.Reader into a folder.
+type ReaderUnarchiver interface {
+	ReaderUnarchive(source io.Reader, size int64, destination string) error
+}
+
 // Writer can write discrete byte streams of files to
 // an output stream.
 type Writer interface {

--- a/archiver_test.go
+++ b/archiver_test.go
@@ -331,6 +331,22 @@ func testArchiveUnarchive(t *testing.T, au archiverUnarchiver) {
 
 	// Check that what was extracted is what was compressed
 	symmetricTest(t, auStr, dest, true, true)
+
+	// Read outfile bytes and create a reader
+	inMemoryBytes, err := ioutil.ReadFile(outfile)
+	if err != nil {
+		t.Fatalf("failed to read in outfile bytes")
+	}
+	reader := bytes.NewReader(inMemoryBytes)
+
+	readerDest := filepath.Join(tmp, "extraction_test_reader"+auStr)
+	os.Mkdir(readerDest, 0755)
+	err = au.ReaderUnarchive(reader, int64(len(inMemoryBytes)), readerDest)
+	if err != nil {
+		t.Fatalf("[%s] extracting archive [reader -> %s]: didn't expect an error, but got: %v", auStr, readerDest, err)
+	}
+	// Check that what was extracted from reader is what was compressed
+	symmetricTest(t, auStr, readerDest, true, true)
 }
 
 // testMatching tests that au can match the format of archiveFile.
@@ -466,6 +482,7 @@ var archiveFormats = []interface{}{
 type archiverUnarchiver interface {
 	Archiver
 	Unarchiver
+	ReaderUnarchiver
 }
 
 type fakeFileInfo struct {

--- a/rar.go
+++ b/rar.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -76,7 +77,7 @@ func (r *Rar) Unarchive(source, destination string) error {
 	// rather than potentially littering the destination...
 	if r.ImplicitTopLevelFolder {
 		var err error
-		destination, err = r.addTopLevelFolder(source, destination)
+		destination, err = r.addTopLevelFolderForFile(source, destination)
 		if err != nil {
 			return fmt.Errorf("scanning source archive: %v", err)
 		}
@@ -88,6 +89,54 @@ func (r *Rar) Unarchive(source, destination string) error {
 	}
 	defer r.Close()
 
+	return r.doUnarchive(destination)
+}
+
+// ReaderUnarchive unpacks the .rar file provided by the
+// io.Reader to destination. Destination will be treated as
+// a folder name. The size parameter is not used. If
+// r.ImplicitTopLevelFolder is true, this operation will
+// fully read the source reader into memory before processing,
+// and the implicit top-level folder will be named "archive".
+func (r *Rar) ReaderUnarchive(source io.Reader, _ int64, destination string) error {
+	if !fileExists(destination) && r.MkdirAll {
+		err := mkdir(destination, 0755)
+		if err != nil {
+			return fmt.Errorf("preparing destination: %v", err)
+		}
+	}
+
+	// if the files in the archive do not all share a common
+	// root, then make sure we extract to a single subfolder
+	// rather than potentially littering the destination...
+	if r.ImplicitTopLevelFolder {
+		// addTopLevelFolder must read entire source: fully read source store bytes in-memory
+		readerBytes, err := ioutil.ReadAll(source)
+		if err != nil {
+			return fmt.Errorf("reading from source reader: %v", err)
+		}
+		// source has been fully read: update it to be a bytes.Reader that reads the bytes
+		source = bytes.NewReader(readerBytes)
+
+		// run addTopLevelFolder using a separate bytes.Reader that reads from the same bytes
+		destination, err = r.addTopLevelFolder(bytes.NewReader(readerBytes), destination, "archive")
+		if err != nil {
+			return fmt.Errorf("scanning source archive: %v", err)
+		}
+	}
+
+	err := r.Open(source, 0)
+	if err != nil {
+		return fmt.Errorf("opening rar archive for reading: %v", err)
+	}
+	defer r.Close()
+
+	return r.doUnarchive(destination)
+}
+
+// doUnarchive performs the unarchive operation. Assumes that checks for destination and handling of implicit top-level
+// folder has already been done and r.Open or r.OpenFile has already been called.
+func (r *Rar) doUnarchive(destination string) error {
 	for {
 		err := r.unrarNext(destination)
 		if err == io.EOF {
@@ -101,22 +150,28 @@ func (r *Rar) Unarchive(source, destination string) error {
 			return fmt.Errorf("reading file in rar archive: %v", err)
 		}
 	}
-
 	return nil
 }
 
-// addTopLevelFolder scans the files contained inside
-// the tarball named sourceArchive and returns a modified
+// addTopLevelFolderForFile scans the files contained inside
+// the rar named sourceArchive and returns a modified
 // destination if all the files do not share the same
 // top-level folder.
-func (r *Rar) addTopLevelFolder(sourceArchive, destination string) (string, error) {
+func (r *Rar) addTopLevelFolderForFile(sourceArchive, destination string) (string, error) {
 	file, err := os.Open(sourceArchive)
 	if err != nil {
 		return "", fmt.Errorf("opening source archive: %v", err)
 	}
 	defer file.Close()
+	return r.addTopLevelFolder(file, destination, folderNameFromFileName(sourceArchive))
+}
 
-	rc, err := rardecode.NewReader(file, r.Password)
+// addTopLevelFolder scans the files contained inside
+// the provided reader (which provides a rar) and returns
+// a modified destination if all the files do not share the
+// same top-level folder.
+func (r *Rar) addTopLevelFolder(sourceArchiveReader io.Reader, destination, folderNameIfMultipleTopLevels string) (string, error) {
+	rc, err := rardecode.NewReader(sourceArchiveReader, r.Password)
 	if err != nil {
 		return "", fmt.Errorf("creating archive reader: %v", err)
 	}
@@ -134,7 +189,7 @@ func (r *Rar) addTopLevelFolder(sourceArchive, destination string) (string, erro
 	}
 
 	if multipleTopLevels(files) {
-		destination = filepath.Join(destination, folderNameFromFileName(sourceArchive))
+		destination = filepath.Join(destination, folderNameIfMultipleTopLevels)
 	}
 
 	return destination, nil
@@ -398,6 +453,7 @@ func (rfi rarFileInfo) Sys() interface{}   { return nil }
 var (
 	_ = Reader(new(Rar))
 	_ = Unarchiver(new(Rar))
+	_ = ReaderUnarchiver(new(Rar))
 	_ = Walker(new(Rar))
 	_ = Extractor(new(Rar))
 	_ = Matcher(new(Rar))

--- a/tar.go
+++ b/tar.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -126,7 +127,7 @@ func (t *Tar) Unarchive(source, destination string) error {
 	// rather than potentially littering the destination...
 	if t.ImplicitTopLevelFolder {
 		var err error
-		destination, err = t.addTopLevelFolder(source, destination)
+		destination, err = t.addTopLevelFolderForFile(source, destination)
 		if err != nil {
 			return fmt.Errorf("scanning source archive: %v", err)
 		}
@@ -161,21 +162,91 @@ func (t *Tar) Unarchive(source, destination string) error {
 	return nil
 }
 
-// addTopLevelFolder scans the files contained inside
+// ReaderUnarchive unpacks the .tar file provided by the
+// io.Reader to destination. Destination will be treated as
+// a folder name. The size parameter is not used. If
+// t.ImplicitTopLevelFolder is true, this operation will
+// fully read the source reader into memory before processing,
+// and the implicit top-level folder will be named "archive".
+func (t *Tar) ReaderUnarchive(source io.Reader, _ int64, destination string) error {
+	if !fileExists(destination) && t.MkdirAll {
+		err := mkdir(destination, 0755)
+		if err != nil {
+			return fmt.Errorf("preparing destination: %v", err)
+		}
+	}
+
+	// if the files in the archive do not all share a common
+	// root, then make sure we extract to a single subfolder
+	// rather than potentially littering the destination...
+	if t.ImplicitTopLevelFolder {
+		// addTopLevelFolder must read entire source: fully read source store bytes in-memory
+		readerBytes, err := ioutil.ReadAll(source)
+		if err != nil {
+			return fmt.Errorf("reading from source reader: %v", err)
+		}
+		// source has been fully read: update it to be a bytes.Reader that reads the bytes
+		source = bytes.NewReader(readerBytes)
+
+		// run addTopLevelFolder using a separate bytes.Reader that reads from the same bytes
+		destination, err = t.addTopLevelFolder(bytes.NewReader(readerBytes), destination, "archive")
+		if err != nil {
+			return fmt.Errorf("scanning source archive: %v", err)
+		}
+	}
+
+	return t.doUnarchive(source, destination)
+}
+
+// doUnarchive performs the unarchive operation given an io.Reader and destination. Assumes that checks for destination
+// and handling of implicit top-level folder has already been done.
+func (t *Tar) doUnarchive(reader io.Reader, destination string) error {
+	err := t.Open(reader, 0)
+	if err != nil {
+		return fmt.Errorf("opening tar archive for reading: %v", err)
+	}
+	defer t.Close()
+
+	for {
+		err := t.untarNext(destination)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			if t.ContinueOnError {
+				log.Printf("[ERROR] Reading file in tar archive: %v", err)
+				continue
+			}
+			return fmt.Errorf("reading file in tar archive: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// addTopLevelFolderForFile scans the files contained inside
 // the tarball named sourceArchive and returns a modified
 // destination if all the files do not share the same
 // top-level folder.
-func (t *Tar) addTopLevelFolder(sourceArchive, destination string) (string, error) {
+func (t *Tar) addTopLevelFolderForFile(sourceArchive, destination string) (string, error) {
 	file, err := os.Open(sourceArchive)
 	if err != nil {
 		return "", fmt.Errorf("opening source archive: %v", err)
 	}
 	defer file.Close()
+	return t.addTopLevelFolder(file, destination, folderNameFromFileName(sourceArchive))
+}
 
+// addTopLevelFolder scans the files contained inside
+// the provided reader (which provides a tarball) and returns
+// a modified destination if all the files do not share the
+// same top-level folder.
+func (t *Tar) addTopLevelFolder(sourceArchiveReader io.Reader, destination, folderNameIfMultipleTopLevels string) (string, error) {
 	// if the reader is to be wrapped, ensure we do that now
 	// or we will not be able to read the archive successfully
-	reader := io.Reader(file)
+	reader := sourceArchiveReader
 	if t.readerWrapFn != nil {
+		var err error
 		reader, err = t.readerWrapFn(reader)
 		if err != nil {
 			return "", fmt.Errorf("wrapping reader: %v", err)
@@ -200,7 +271,7 @@ func (t *Tar) addTopLevelFolder(sourceArchive, destination string) (string, erro
 	}
 
 	if multipleTopLevels(files) {
-		destination = filepath.Join(destination, folderNameFromFileName(sourceArchive))
+		destination = filepath.Join(destination, folderNameIfMultipleTopLevels)
 	}
 
 	return destination, nil
@@ -608,6 +679,7 @@ var (
 	_ = Writer(new(Tar))
 	_ = Archiver(new(Tar))
 	_ = Unarchiver(new(Tar))
+	_ = ReaderUnarchiver(new(Tar))
 	_ = Walker(new(Tar))
 	_ = Extractor(new(Tar))
 	_ = Matcher(new(Tar))

--- a/tarbrotli.go
+++ b/tarbrotli.go
@@ -45,6 +45,14 @@ func (tbr *TarBrotli) Unarchive(source, destination string) error {
 	return tbr.Tar.Unarchive(source, destination)
 }
 
+// ReaderUnarchive unpacks the compressed tarball
+// provided by source to destination. Destination
+// will be treated as a folder name.
+func (tbr *TarBrotli) ReaderUnarchive(source io.Reader, _ int64, destination string) error {
+	tbr.wrapReader()
+	return tbr.Tar.ReaderUnarchive(source, 0, destination)
+}
+
 // Walk calls walkFn for each visited item in archive.
 func (tbr *TarBrotli) Walk(archive string, walkFn WalkFunc) error {
 	tbr.wrapReader()
@@ -106,6 +114,7 @@ var (
 	_ = Writer(new(TarBrotli))
 	_ = Archiver(new(TarBrotli))
 	_ = Unarchiver(new(TarBrotli))
+	_ = ReaderUnarchiver(new(Rar))
 	_ = Walker(new(TarBrotli))
 	_ = Extractor(new(TarBrotli))
 )

--- a/tarbz2.go
+++ b/tarbz2.go
@@ -48,6 +48,14 @@ func (tbz2 *TarBz2) Unarchive(source, destination string) error {
 	return tbz2.Tar.Unarchive(source, destination)
 }
 
+// ReaderUnarchive unpacks the compressed tarball
+// provided by source to destination. Destination
+// will be treated as a folder name.
+func (tbz2 *TarBz2) ReaderUnarchive(source io.Reader, _ int64, destination string) error {
+	tbz2.wrapReader()
+	return tbz2.Tar.ReaderUnarchive(source, 0, destination)
+}
+
 // Walk calls walkFn for each visited item in archive.
 func (tbz2 *TarBz2) Walk(archive string, walkFn WalkFunc) error {
 	tbz2.wrapReader()
@@ -118,6 +126,7 @@ var (
 	_ = Writer(new(TarBz2))
 	_ = Archiver(new(TarBz2))
 	_ = Unarchiver(new(TarBz2))
+	_ = ReaderUnarchiver(new(Rar))
 	_ = Walker(new(TarBz2))
 	_ = Extractor(new(TarBz2))
 )

--- a/targz.go
+++ b/targz.go
@@ -53,6 +53,14 @@ func (tgz *TarGz) Unarchive(source, destination string) error {
 	return tgz.Tar.Unarchive(source, destination)
 }
 
+// ReaderUnarchive unpacks the compressed tarball
+// provided by source to destination. Destination
+// will be treated as a folder name.
+func (tgz *TarGz) ReaderUnarchive(source io.Reader, _ int64, destination string) error {
+	tgz.wrapReader()
+	return tgz.Tar.ReaderUnarchive(source, 0, destination)
+}
+
 // Walk calls walkFn for each visited item in archive.
 func (tgz *TarGz) Walk(archive string, walkFn WalkFunc) error {
 	tgz.wrapReader()
@@ -129,6 +137,7 @@ var (
 	_ = Writer(new(TarGz))
 	_ = Archiver(new(TarGz))
 	_ = Unarchiver(new(TarGz))
+	_ = ReaderUnarchiver(new(TarGz))
 	_ = Walker(new(TarGz))
 	_ = Extractor(new(TarGz))
 )

--- a/tarlz4.go
+++ b/tarlz4.go
@@ -52,6 +52,14 @@ func (tlz4 *TarLz4) Unarchive(source, destination string) error {
 	return tlz4.Tar.Unarchive(source, destination)
 }
 
+// ReaderUnarchive unpacks the compressed tarball
+// provided by source to destination. Destination
+// will be treated as a folder name.
+func (tlz4 *TarLz4) ReaderUnarchive(source io.Reader, _ int64, destination string) error {
+	tlz4.wrapReader()
+	return tlz4.Tar.ReaderUnarchive(source, 0, destination)
+}
+
 // Walk calls walkFn for each visited item in archive.
 func (tlz4 *TarLz4) Walk(archive string, walkFn WalkFunc) error {
 	tlz4.wrapReader()
@@ -114,6 +122,7 @@ var (
 	_ = Writer(new(TarLz4))
 	_ = Archiver(new(TarLz4))
 	_ = Unarchiver(new(TarLz4))
+	_ = ReaderUnarchiver(new(Rar))
 	_ = Walker(new(TarLz4))
 	_ = Extractor(new(TarLz4))
 )

--- a/tarsz.go
+++ b/tarsz.go
@@ -46,6 +46,14 @@ func (tsz *TarSz) Unarchive(source, destination string) error {
 	return tsz.Tar.Unarchive(source, destination)
 }
 
+// ReaderUnarchive unpacks the compressed tarball
+// provided by source to destination. Destination
+// will be treated as a folder name.
+func (tsz *TarSz) ReaderUnarchive(source io.Reader, _ int64, destination string) error {
+	tsz.wrapReader()
+	return tsz.Tar.ReaderUnarchive(source, 0, destination)
+}
+
 // Walk calls walkFn for each visited item in archive.
 func (tsz *TarSz) Walk(archive string, walkFn WalkFunc) error {
 	tsz.wrapReader()
@@ -106,6 +114,7 @@ var (
 	_ = Writer(new(TarSz))
 	_ = Archiver(new(TarSz))
 	_ = Unarchiver(new(TarSz))
+	_ = ReaderUnarchiver(new(Rar))
 	_ = Walker(new(TarSz))
 	_ = Extractor(new(TarSz))
 )

--- a/tarxz.go
+++ b/tarxz.go
@@ -47,6 +47,14 @@ func (txz *TarXz) Unarchive(source, destination string) error {
 	return txz.Tar.Unarchive(source, destination)
 }
 
+// ReaderUnarchive unpacks the compressed tarball
+// provided by source to destination. Destination
+// will be treated as a folder name.
+func (txz *TarXz) ReaderUnarchive(source io.Reader, _ int64, destination string) error {
+	txz.wrapReader()
+	return txz.Tar.ReaderUnarchive(source, 0, destination)
+}
+
 // Walk calls walkFn for each visited item in archive.
 func (txz *TarXz) Walk(archive string, walkFn WalkFunc) error {
 	txz.wrapReader()
@@ -111,6 +119,7 @@ var (
 	_ = Writer(new(TarXz))
 	_ = Archiver(new(TarXz))
 	_ = Unarchiver(new(TarXz))
+	_ = ReaderUnarchiver(new(Rar))
 	_ = Walker(new(TarXz))
 	_ = Extractor(new(TarXz))
 )

--- a/tarzst.go
+++ b/tarzst.go
@@ -44,6 +44,14 @@ func (tzst *TarZstd) Unarchive(source, destination string) error {
 	return tzst.Tar.Unarchive(source, destination)
 }
 
+// ReaderUnarchive unpacks the compressed tarball
+// provided by source to destination. Destination
+// will be treated as a folder name.
+func (tzst *TarZstd) ReaderUnarchive(source io.Reader, _ int64, destination string) error {
+	tzst.wrapReader()
+	return tzst.Tar.ReaderUnarchive(source, 0, destination)
+}
+
 // Walk calls walkFn for each visited item in archive.
 func (tzst *TarZstd) Walk(archive string, walkFn WalkFunc) error {
 	tzst.wrapReader()
@@ -111,6 +119,7 @@ var (
 	_ = Writer(new(TarZstd))
 	_ = Archiver(new(TarZstd))
 	_ = Unarchiver(new(TarZstd))
+	_ = ReaderUnarchiver(new(Rar))
 	_ = Walker(new(TarZstd))
 	_ = ExtensionChecker(new(TarZstd))
 	_ = Extractor(new(TarZstd))

--- a/zip.go
+++ b/zip.go
@@ -122,13 +122,6 @@ func (z *Zip) Archive(sources []string, destination string) error {
 // Unarchive unpacks the .zip file at source to destination.
 // Destination will be treated as a folder name.
 func (z *Zip) Unarchive(source, destination string) error {
-	if !fileExists(destination) && z.MkdirAll {
-		err := mkdir(destination, 0755)
-		if err != nil {
-			return fmt.Errorf("preparing destination: %v", err)
-		}
-	}
-
 	file, err := os.Open(source)
 	if err != nil {
 		return fmt.Errorf("opening source file: %v", err)
@@ -140,7 +133,22 @@ func (z *Zip) Unarchive(source, destination string) error {
 		return fmt.Errorf("statting source file: %v", err)
 	}
 
-	err = z.Open(file, fileInfo.Size())
+	return z.doUnarchive(file, fileInfo.Size(), destination, folderNameFromFileName(source))
+}
+
+func (z *Zip) ReaderUnarchive(source io.Reader, size int64, destination string) error {
+	return z.doUnarchive(source, size, destination, "archive")
+}
+
+func (z *Zip) doUnarchive(source io.Reader, size int64, destination, folderNameIfMultipleTopLevels string) error {
+	if !fileExists(destination) && z.MkdirAll {
+		err := mkdir(destination, 0755)
+		if err != nil {
+			return fmt.Errorf("preparing destination: %v", err)
+		}
+	}
+
+	err := z.Open(source, size)
 	if err != nil {
 		return fmt.Errorf("opening zip archive for reading: %v", err)
 	}
@@ -155,7 +163,7 @@ func (z *Zip) Unarchive(source, destination string) error {
 			files[i] = z.zr.File[i].Name
 		}
 		if multipleTopLevels(files) {
-			destination = filepath.Join(destination, folderNameFromFileName(source))
+			destination = filepath.Join(destination, folderNameIfMultipleTopLevels)
 		}
 	}
 
@@ -556,6 +564,7 @@ var (
 	_ = Writer(new(Zip))
 	_ = Archiver(new(Zip))
 	_ = Unarchiver(new(Zip))
+	_ = ReaderUnarchiver(new(Rar))
 	_ = Walker(new(Zip))
 	_ = Extractor(new(Zip))
 	_ = Matcher(new(Zip))


### PR DESCRIPTION
This commit adds a new ReaderUnarchive interface, which supports
performing an Unarchive operation from an io.Reader with a provided
size.

Fixes #150
Addresses #131