### PR TITLE
Add WriterArchiver interface and provide implementations

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -67,6 +67,13 @@ type Archiver interface {
 	Archive(sources []string, destination string) error
 }
 
+// WriterArchiver is a type that can create an archive
+// from a list of source file names and write it to an
+// io.Writer.
+type WriterArchiver interface {
+	WriterArchive(sources []string, destination io.Writer) error
+}
+
 // ExtensionChecker validates file extensions
 type ExtensionChecker interface {
 	CheckExt(name string) error

--- a/tarbrotli.go
+++ b/tarbrotli.go
@@ -37,6 +37,15 @@ func (tbr *TarBrotli) Archive(sources []string, destination string) error {
 	return tbr.Tar.Archive(sources, destination)
 }
 
+// WriterArchive writes a compressed tar file to the destination
+// io.Writer containing the files listed in sources. File paths
+// can be those of regular files or directories; directories will
+// be recursively added.
+func (tbr *TarBrotli) WriterArchive(sources []string, destination io.Writer) error {
+	tbr.wrapWriter()
+	return tbr.Tar.WriterArchive(sources, destination)
+}
+
 // Unarchive unpacks the compressed tarball at
 // source to destination. Destination will be
 // treated as a folder name.
@@ -105,6 +114,7 @@ var (
 	_ = Reader(new(TarBrotli))
 	_ = Writer(new(TarBrotli))
 	_ = Archiver(new(TarBrotli))
+	_ = WriterArchiver(new(TarBrotli))
 	_ = Unarchiver(new(TarBrotli))
 	_ = Walker(new(TarBrotli))
 	_ = Extractor(new(TarBrotli))

--- a/tarbz2.go
+++ b/tarbz2.go
@@ -40,6 +40,15 @@ func (tbz2 *TarBz2) Archive(sources []string, destination string) error {
 	return tbz2.Tar.Archive(sources, destination)
 }
 
+// WriterArchive writes a compressed tar file to the destination
+// io.Writer containing the files listed in sources. File paths
+// can be those of regular files or directories; directories will
+// be recursively added.
+func (tbz2 *TarBz2) WriterArchive(sources []string, destination io.Writer) error {
+	tbz2.wrapWriter()
+	return tbz2.Tar.WriterArchive(sources, destination)
+}
+
 // Unarchive unpacks the compressed tarball at
 // source to destination. Destination will be
 // treated as a folder name.

--- a/targz.go
+++ b/targz.go
@@ -45,6 +45,15 @@ func (tgz *TarGz) Archive(sources []string, destination string) error {
 	return tgz.Tar.Archive(sources, destination)
 }
 
+// WriterArchive writes a compressed tar file to the destination
+// io.Writer containing the files listed in sources. File paths
+// can be those of regular files or directories; directories will
+// be recursively added.
+func (tgz *TarGz) WriterArchive(sources []string, destination io.Writer) error {
+	tgz.wrapWriter()
+	return tgz.Tar.WriterArchive(sources, destination)
+}
+
 // Unarchive unpacks the compressed tarball at
 // source to destination. Destination will be
 // treated as a folder name.
@@ -128,6 +137,7 @@ var (
 	_ = Reader(new(TarGz))
 	_ = Writer(new(TarGz))
 	_ = Archiver(new(TarGz))
+	_ = WriterArchiver(new(TarGz))
 	_ = Unarchiver(new(TarGz))
 	_ = Walker(new(TarGz))
 	_ = Extractor(new(TarGz))

--- a/tarlz4.go
+++ b/tarlz4.go
@@ -44,6 +44,15 @@ func (tlz4 *TarLz4) Archive(sources []string, destination string) error {
 	return tlz4.Tar.Archive(sources, destination)
 }
 
+// WriterArchive writes a compressed tar file to the destination
+// io.Writer containing the files listed in sources. File paths
+// can be those of regular files or directories; directories will
+// be recursively added.
+func (tlz4 *TarLz4) WriterArchive(sources []string, destination io.Writer) error {
+	tlz4.wrapWriter()
+	return tlz4.Tar.WriterArchive(sources, destination)
+}
+
 // Unarchive unpacks the compressed tarball at
 // source to destination. Destination will be
 // treated as a folder name.
@@ -113,6 +122,7 @@ var (
 	_ = Reader(new(TarLz4))
 	_ = Writer(new(TarLz4))
 	_ = Archiver(new(TarLz4))
+	_ = WriterArchiver(new(TarLz4))
 	_ = Unarchiver(new(TarLz4))
 	_ = Walker(new(TarLz4))
 	_ = Extractor(new(TarLz4))

--- a/tarsz.go
+++ b/tarsz.go
@@ -38,6 +38,15 @@ func (tsz *TarSz) Archive(sources []string, destination string) error {
 	return tsz.Tar.Archive(sources, destination)
 }
 
+// WriterArchive writes a compressed tar file to the destination
+// io.Writer containing the files listed in sources. File paths
+// can be those of regular files or directories; directories will
+// be recursively added.
+func (tsz *TarSz) WriterArchive(sources []string, destination io.Writer) error {
+	tsz.wrapWriter()
+	return tsz.Tar.WriterArchive(sources, destination)
+}
+
 // Unarchive unpacks the compressed tarball at
 // source to destination. Destination will be
 // treated as a folder name.
@@ -105,6 +114,7 @@ var (
 	_ = Reader(new(TarSz))
 	_ = Writer(new(TarSz))
 	_ = Archiver(new(TarSz))
+	_ = WriterArchiver(new(TarSz))
 	_ = Unarchiver(new(TarSz))
 	_ = Walker(new(TarSz))
 	_ = Extractor(new(TarSz))

--- a/tarxz.go
+++ b/tarxz.go
@@ -39,6 +39,15 @@ func (txz *TarXz) Archive(sources []string, destination string) error {
 	return txz.Tar.Archive(sources, destination)
 }
 
+// WriterArchive writes a compressed tar file to the destination
+// io.Writer containing the files listed in sources. File paths
+// can be those of regular files or directories; directories will
+// be recursively added.
+func (txz *TarXz) WriterArchive(sources []string, destination io.Writer) error {
+	txz.wrapWriter()
+	return txz.Tar.WriterArchive(sources, destination)
+}
+
 // Unarchive unpacks the compressed tarball at
 // source to destination. Destination will be
 // treated as a folder name.
@@ -110,6 +119,7 @@ var (
 	_ = Reader(new(TarXz))
 	_ = Writer(new(TarXz))
 	_ = Archiver(new(TarXz))
+	_ = WriterArchiver(new(TarXz))
 	_ = Unarchiver(new(TarXz))
 	_ = Walker(new(TarXz))
 	_ = Extractor(new(TarXz))

--- a/tarzst.go
+++ b/tarzst.go
@@ -36,6 +36,15 @@ func (tzst *TarZstd) Archive(sources []string, destination string) error {
 	return tzst.Tar.Archive(sources, destination)
 }
 
+// WriterArchive writes a compressed tar file to the destination
+// io.Writer containing the files listed in sources. File paths
+// can be those of regular files or directories; directories will
+// be recursively added.
+func (tzst *TarZstd) WriterArchive(sources []string, destination io.Writer) error {
+	tzst.wrapWriter()
+	return tzst.Tar.WriterArchive(sources, destination)
+}
+
 // Unarchive unpacks the compressed tarball at
 // source to destination. Destination will be
 // treated as a folder name.
@@ -110,6 +119,7 @@ var (
 	_ = Reader(new(TarZstd))
 	_ = Writer(new(TarZstd))
 	_ = Archiver(new(TarZstd))
+	_ = WriterArchiver(new(TarZstd))
 	_ = Unarchiver(new(TarZstd))
 	_ = Walker(new(TarZstd))
 	_ = ExtensionChecker(new(TarZstd))


### PR DESCRIPTION
This commit adds a new WriterUnarchiver interface, which supports
performing an Archive operation to an io.Writer.

Fixes #131 when paired with #199