### PR TITLE
Fix issue when reading symlink during tar Archive

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -105,6 +105,9 @@ type Extractor interface {
 type File struct {
 	os.FileInfo
 
+	// OriginalPath is the original full path to file
+	OriginalPath string
+
 	// The original header info; depends on
 	// type of archive -- could be nil, too.
 	Header interface{}

--- a/tar.go
+++ b/tar.go
@@ -295,6 +295,7 @@ func (t *Tar) writeWalk(source, topLevelFolder, destination string) error {
 				FileInfo:   info,
 				CustomName: nameInArchive,
 			},
+			OriginalPath: fpath,
 			ReadCloser: file,
 		})
 		if err != nil {
@@ -340,7 +341,7 @@ func (t *Tar) Write(f File) error {
 	var linkTarget string
 	if isSymlink(f) {
 		var err error
-		linkTarget, err = os.Readlink(f.Name())
+		linkTarget, err = os.Readlink(f.OriginalPath)
 		if err != nil {
 			return fmt.Errorf("%s: readlink: %v", f.Name(), err)
 		}


### PR DESCRIPTION
This PR fixes an issue when create tar archives with symbolic links. 

The code uses the `Name()` value to call `os.Readlink()`. This does not work since this value is only the name of the link. not the full path.

To resolve this, we need to pass down the original full FS path and use it during `os.*` calls.

Fixes #202 