### PR TITLE
Replace Zip and Flate packages.

### DIFF
--- a/zip.go
+++ b/zip.go
@@ -1,9 +1,7 @@
 package archiver
 
 import (
-	"archive/zip"
 	"bytes"
-	"compress/flate"
 	"fmt"
 	"io"
 	"log"
@@ -11,6 +9,9 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/klauspost/compress/flate"
+	"github.com/klauspost/compress/zip"
 )
 
 // Zip provides facilities for operating ZIP archives.


### PR DESCRIPTION
Use the optimized versions from github.com/klauspost/compress.
In smoke tests, compressing 7K files took 3 seconds, rather than 12
seconds with the official packages.