### PR TITLE
Added FullPath to File for Zips.

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -103,6 +103,8 @@ type Extractor interface {
 // File provides methods for accessing information about
 // or contents of a file within an archive.
 type File struct {
+	FullPath string
+
 	os.FileInfo
 
 	// The original header info; depends on

--- a/zip.go
+++ b/zip.go
@@ -445,6 +445,7 @@ func (z *Zip) Walk(archive string, walkFn WalkFunc) error {
 		}
 
 		err = walkFn(File{
+			FullPath:   zf.Name,
 			FileInfo:   zf.FileInfo(),
 			Header:     zf.FileHeader,
 			ReadCloser: zfrc,


### PR DESCRIPTION
Hi @mholt, saw that you're busy with Caddy, all good I'll use my fork for a while. 

Related to #130.

When you have time, can this be considered? There's a lot missing, the `File` is used everywhere and I only needed it when walking around a Zip, but perhaps we can discuss making this work for everything and get the PR in.