### PR TITLE
use 'go get' because 'go install' does not get

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Tar files can optionally be compressed using any of the above compression format
 To install the runnable binary to your $GOPATH/bin:
 
 ```bash
-$ go install github.com/mholt/archiver/cmd/arc
+$ go get github.com/mholt/archiver/cmd/arc
 ```
 
 Or download binaries from the [releases](https://github.com/mholt/archiver/releases) page.


### PR DESCRIPTION
Oddly enough `go install` will not `go get`, but `go get` will `go install`, and so 'go get' does what is intended (download and install) whereas 'go install' does not (it only builds and installs from cache).