### PR TITLE
Added IllegalPathError

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,27 @@
+package archiver
+
+import (
+	"fmt"
+	"strings"
+)
+
+// IllegalPathError is an error returned when an illegal
+// path is detected during the archival process.
+//
+// By default, only the Filename is showed on error, but you might
+// also get the absolute value of the invalid path on the AbsolutePath
+// field.
+type IllegalPathError struct {
+	AbsolutePath string
+	Filename     string
+}
+
+func (err *IllegalPathError) Error() string {
+	return fmt.Sprintf("illegal file path: %s", err.Filename)
+}
+
+// IsIllegalPathError returns true if the provided error is of
+// the type IllegalPathError.
+func IsIllegalPathError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "illegal file path: ")
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,54 @@
+package archiver_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/mholt/archiver/v3"
+)
+
+func TestIllegalPathErrorString(t *testing.T) {
+	tests := []struct {
+		instance *archiver.IllegalPathError
+		expected string
+	}{
+		{instance: &archiver.IllegalPathError{Filename: "foo.txt"}, expected: "illegal file path: foo.txt"},
+		{instance: &archiver.IllegalPathError{AbsolutePath: "/tmp/bar.txt", Filename: "bar.txt"}, expected: "illegal file path: bar.txt"},
+	}
+
+	for i, test := range tests {
+		test := test
+
+		t.Run(fmt.Sprintf("Case %d", i), func(t *testing.T) {
+			if test.expected != test.instance.Error() {
+				t.Fatalf("Excepected '%s', but got '%s'", test.expected, test.instance.Error())
+			}
+		})
+	}
+}
+
+func TestIsIllegalPathError(t *testing.T) {
+	tests := []struct {
+		instance error
+		expected bool
+	}{
+		{instance: nil, expected: false},
+		{instance: os.ErrNotExist, expected: false},
+		{instance: fmt.Errorf("some error"), expected: false},
+		{instance: errors.New("another error"), expected: false},
+		{instance: &archiver.IllegalPathError{Filename: "foo.txt"}, expected: true},
+	}
+
+	for i, test := range tests {
+		test := test
+
+		t.Run(fmt.Sprintf("Case %d", i), func(t *testing.T) {
+			actual := archiver.IsIllegalPathError(test.instance)
+			if actual != test.expected {
+				t.Fatalf("Excepected '%v', but got '%v'", test.expected, actual)
+			}
+		})
+	}
+}

--- a/rar.go
+++ b/rar.go
@@ -66,7 +66,7 @@ func (*Rar) CheckPath(to, filename string) error {
 	dest := filepath.Join(to, filename)
 	//prevent path traversal attacks
 	if !strings.HasPrefix(dest, to) {
-		return fmt.Errorf("illegal file path: %s", filename)
+		return &IllegalPathError{AbsolutePath: dest, Filename: filename}
 	}
 	return nil
 }
@@ -105,7 +105,7 @@ func (r *Rar) Unarchive(source, destination string) error {
 			break
 		}
 		if err != nil {
-			if r.ContinueOnError || strings.Contains(err.Error(), "illegal file path") {
+			if r.ContinueOnError || IsIllegalPathError(err) {
 				log.Printf("[ERROR] Reading file in rar archive: %v", err)
 				continue
 			}

--- a/tar.go
+++ b/tar.go
@@ -67,7 +67,7 @@ func (*Tar) CheckPath(to, filename string) error {
 	dest := filepath.Join(to, filename)
 	//prevent path traversal attacks
 	if !strings.HasPrefix(dest, to) {
-		return fmt.Errorf("illegal file path: %s", filename)
+		return &IllegalPathError{AbsolutePath: dest, Filename: filename}
 	}
 	return nil
 }
@@ -161,7 +161,7 @@ func (t *Tar) Unarchive(source, destination string) error {
 			break
 		}
 		if err != nil {
-			if t.ContinueOnError || strings.Contains(err.Error(), "illegal file path") {
+			if t.ContinueOnError || IsIllegalPathError(err) {
 				log.Printf("[ERROR] Reading file in tar archive: %v", err)
 				continue
 			}

--- a/zip.go
+++ b/zip.go
@@ -123,7 +123,7 @@ func (*Zip) CheckPath(to, filename string) error {
 	dest := filepath.Join(to, filename)
 	//prevent path traversal attacks
 	if !strings.HasPrefix(dest, to) {
-		return fmt.Errorf("illegal file path: %s", filename)
+		return &IllegalPathError{AbsolutePath: dest, Filename: filename}
 	}
 	return nil
 }
@@ -225,7 +225,7 @@ func (z *Zip) Unarchive(source, destination string) error {
 			break
 		}
 		if err != nil {
-			if z.ContinueOnError || strings.Contains(err.Error(), "illegal file path") {
+			if z.ContinueOnError || IsIllegalPathError(err) {
 				log.Printf("[ERROR] Reading file in zip archive: %v", err)
 				continue
 			}


### PR DESCRIPTION
Created a `IllegalPathError` struct, as well as a the `IsIllegalPathError` helper function.
Note that the struct has an additional field, `AbsolutePath`, that is **not** used for printing, but might be useful for for debugging purposes to library users.