### PR TITLE
Switch zip handling to use github.com/klauspost/compress/zip

### DIFF
--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"archive/tar"
-	"archive/zip"
 	"bytes"
 	"compress/flate"
 	"flag"
@@ -11,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/klauspost/compress/zip"
 	"github.com/mholt/archiver/v3"
 	"github.com/nwaples/rardecode"
 )

--- a/testdata/create-evil-zip.go
+++ b/testdata/create-evil-zip.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"archive/zip"
 	"log"
 	"os"
 	"time"
+
+	"github.com/klauspost/compress/zip"
 )
 
 func main() {

--- a/zip.go
+++ b/zip.go
@@ -1,7 +1,6 @@
 package archiver
 
 import (
-	"archive/zip"
 	"bytes"
 	"compress/flate"
 	"fmt"
@@ -14,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/dsnet/compress/bzip2"
+	"github.com/klauspost/compress/zip"
 	"github.com/klauspost/compress/zstd"
 	"github.com/ulikunitz/xz"
 )


### PR DESCRIPTION
This improves the performance over the stdlib implementation.
Archiving seems to be about 2.5x faster in my tests and archiving seems to be around 1.2x faster.
Those numbers should be even better after https://github.com/mholt/archiver/pull/272 is merged with the updated of the compression library.