### PR TITLE
Customize default values

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -480,6 +480,66 @@ func ByExtension(filename string) (interface{}, error) {
 	return nil, fmt.Errorf("format unrecognized by filename: %s", filename)
 }
 
+// Customize customize an archiver and unarchiver, or compressor
+// and decompressor, based on CustomizeParams struct.
+func Customize(f interface{}, params CustomizeParams) (interface{}, error) {
+	switch v := f.(type) {
+	case *Rar:
+		v.OverwriteExisting = params.OverwriteExisting
+		v.MkdirAll = params.MkdirAll
+		v.ImplicitTopLevelFolder = params.ImplicitTopLevelFolder
+		v.StripComponents = params.StripComponents
+		v.ContinueOnError = params.ContinueOnError
+		v.Password = params.Password
+	case *Tar:
+		f = params.Tar
+	case *TarBrotli:
+		v.Tar = params.Tar
+		v.Quality = params.CompressionLevel
+	case *TarBz2:
+		v.Tar = params.Tar
+		v.CompressionLevel = params.CompressionLevel
+	case *TarGz:
+		v.Tar = params.Tar
+		v.CompressionLevel = params.CompressionLevel
+	case *TarLz4:
+		v.Tar = params.Tar
+		v.CompressionLevel = params.CompressionLevel
+	case *TarSz:
+		v.Tar = params.Tar
+	case *TarXz:
+		v.Tar = params.Tar
+	case *TarZstd:
+		v.Tar = params.Tar
+	case *Zip:
+		v.CompressionLevel = params.CompressionLevel
+		v.OverwriteExisting = params.OverwriteExisting
+		v.MkdirAll = params.MkdirAll
+		v.SelectiveCompression = params.SelectiveCompression
+		v.ImplicitTopLevelFolder = params.ImplicitTopLevelFolder
+		v.StripComponents = params.StripComponents
+		v.ContinueOnError = params.ContinueOnError
+	case *Gz:
+		v.CompressionLevel = params.CompressionLevel
+	case *Brotli:
+		v.Quality = params.CompressionLevel
+	case *Bz2:
+		v.CompressionLevel = params.CompressionLevel
+	case *Lz4:
+		v.CompressionLevel = params.CompressionLevel
+	case *Snappy:
+		// nothing to customize
+	case *Xz:
+		// nothing to customize
+	case *Zstd:
+		// nothing to customize
+	default:
+		return nil, fmt.Errorf("format does not support customization: %s", f)
+	}
+
+	return f, nil
+}
+
 // ByHeader returns the unarchiver value that matches the input's
 // file header. It does not affect the current read position.
 // If the file's header is not a recognized archive format, then
@@ -534,4 +594,11 @@ var matchers = []Matcher{
 	&Rar{},
 	&Tar{},
 	&Zip{},
+}
+
+type CustomizeParams struct {
+	*Tar
+	SelectiveCompression bool
+	Password             string
+	CompressionLevel     int
 }

--- a/cmd/arc/main.go
+++ b/cmd/arc/main.go
@@ -220,71 +220,20 @@ func getFormat(subcommand string) (interface{}, error) {
 		return nil, err
 	}
 
-	// prepare a single Tar, in case it's needed
-	mytar := &archiver.Tar{
-		OverwriteExisting:      overwriteExisting,
-		MkdirAll:               mkdirAll,
-		ImplicitTopLevelFolder: implicitTopLevelFolder,
-		StripComponents:        stripComponents,
-		ContinueOnError:        continueOnError,
+	params := archiver.CustomizeParams{
+		Tar: &archiver.Tar{
+			OverwriteExisting:      overwriteExisting,
+			MkdirAll:               mkdirAll,
+			ImplicitTopLevelFolder: implicitTopLevelFolder,
+			StripComponents:        stripComponents,
+			ContinueOnError:        continueOnError,
+		},
+		CompressionLevel:     compressionLevel,
+		Password:             os.Getenv("ARCHIVE_PASSWORD"),
+		SelectiveCompression: selectiveCompression,
 	}
 
-	// fully configure the new value
-	switch v := f.(type) {
-	case *archiver.Rar:
-		v.OverwriteExisting = overwriteExisting
-		v.MkdirAll = mkdirAll
-		v.ImplicitTopLevelFolder = implicitTopLevelFolder
-		v.StripComponents = stripComponents
-		v.ContinueOnError = continueOnError
-		v.Password = os.Getenv("ARCHIVE_PASSWORD")
-	case *archiver.Tar:
-		f = mytar
-	case *archiver.TarBrotli:
-		v.Tar = mytar
-		v.Quality = compressionLevel
-	case *archiver.TarBz2:
-		v.Tar = mytar
-		v.CompressionLevel = compressionLevel
-	case *archiver.TarGz:
-		v.Tar = mytar
-		v.CompressionLevel = compressionLevel
-	case *archiver.TarLz4:
-		v.Tar = mytar
-		v.CompressionLevel = compressionLevel
-	case *archiver.TarSz:
-		v.Tar = mytar
-	case *archiver.TarXz:
-		v.Tar = mytar
-	case *archiver.TarZstd:
-		v.Tar = mytar
-	case *archiver.Zip:
-		v.CompressionLevel = compressionLevel
-		v.OverwriteExisting = overwriteExisting
-		v.MkdirAll = mkdirAll
-		v.SelectiveCompression = selectiveCompression
-		v.ImplicitTopLevelFolder = implicitTopLevelFolder
-		v.StripComponents = stripComponents
-		v.ContinueOnError = continueOnError
-	case *archiver.Gz:
-		v.CompressionLevel = compressionLevel
-	case *archiver.Brotli:
-		v.Quality = compressionLevel
-	case *archiver.Bz2:
-		v.CompressionLevel = compressionLevel
-	case *archiver.Lz4:
-		v.CompressionLevel = compressionLevel
-	case *archiver.Snappy:
-		// nothing to customize
-	case *archiver.Xz:
-		// nothing to customize
-	case *archiver.Zstd:
-		// nothing to customize
-	default:
-		return nil, fmt.Errorf("format does not support customization: %s", f)
-	}
-
-	return f, nil
+	return archiver.Customize(f, params)
 }
 
 func fatal(v ...interface{}) {


### PR DESCRIPTION
This PR adds the ability to set the default values for all types which support it, e.g.:
Right now the following code will use the default values of a gz archiver instance. In order to set the default values (e.g. override=true), we have to create an instance of gz and configure it.

```err = archiver.Unarchive("test.tar.gz", "test")```

After this PR will be merged, you will be able to create a new archiver instance and configure it before use e.g.:
```
func Unarchive(localArchivePath, originArchiveName, destinationPath string) error {
	// Create archiver instance based on file extention.
	archiverInterface, err := archiver.ByExtension(originArchiveName)

	// Create default values.
	params := archiver.CustomizeParams{
		Tar: &archiver.Tar{
			OverwriteExisting: true,
		},
	}

	// Set default values for an archiver instance.
	archiverInterface, err = archiver.Customize(archiverInterface, params)
	if err != nil {
		return err
	}
	u, ok := archiverInterface.(archiver.Unarchiver)
	if !ok {
		return errorutils.CheckError(errors.New("format specified by source filename is not an archive format: " + originArchiveName))
	}

	// Run the archiver methods.
	return u.Unarchive(localArchivePath, destinationPath)
}
```
Fixes: https://github.com/mholt/archiver/issues/264