### PR TITLE
Use go error wrapping for easier error handling

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -399,7 +399,7 @@ func (t *Tar) Write(f File) error {
 		}
 		_, err := io.Copy(t.tw, f)
 		if err != nil {
-			return fmt.Errorf("%s: copying contents: %v", f.Name(), err)
+			return fmt.Errorf("%s: copying contents: %w", f.Name(), err)
 		}
 	}
 

--- a/zip.go
+++ b/zip.go
@@ -448,7 +448,7 @@ func (z *Zip) writeFile(f File, writer io.Writer) error {
 	}
 	_, err := io.Copy(writer, f)
 	if err != nil {
-		return fmt.Errorf("%s: copying contents: %v", f.Name(), err)
+		return fmt.Errorf("%s: copying contents: %w", f.Name(), err)
 	}
 
 	return nil


### PR DESCRIPTION
This will make it easier for user's of this library (like me :) ) to filter out the different underlying errors and handle them.

For more information, see:

https://blog.golang.org/go1.13-errors
