### PR TITLE
Use go error wrapping on header writing for easier error handling

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -386,7 +386,7 @@ func (t *Tar) Write(f File) error {
 
 	err = t.tw.WriteHeader(hdr)
 	if err != nil {
-		return fmt.Errorf("%s: writing header: %v", hdr.Name, err)
+		return fmt.Errorf("%s: writing header: %w", hdr.Name, err)
 	}
 
 	if f.IsDir() {

--- a/zip.go
+++ b/zip.go
@@ -420,7 +420,7 @@ func (z *Zip) Write(f File) error {
 
 	writer, err := z.zw.CreateHeader(header)
 	if err != nil {
-		return fmt.Errorf("%s: making header: %v", f.Name(), err)
+		return fmt.Errorf("%s: making header: %w", f.Name(), err)
 	}
 
 	return z.writeFile(f, writer)


### PR DESCRIPTION
Followup on #276 

I now get errors like these:

`path/to/file: making header: write tcp 10.2.0.6:8080->10.99.12.11:52284: write: broken pipe`

I would like to filter these too :)
