### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ curl.exe -fsS -A MS https://webinstall.dev/arc | powershell
 To install the runnable binary to your \$GOPATH/bin:
 
 ```bash
-go get github.com/mholt/archiver/cmd/arc
+go install github.com/mholt/archiver/v3/cmd/arc@latest
 ```
 
 ### Manually


### PR DESCRIPTION
Fix the install instructions for current versions of Go, since trying the current suggestion will likely lead the user through a trail of unhelpful error messages.