### PR TITLE
Bugfix issue#222

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -125,6 +125,9 @@ type File struct {
 type FileInfo struct {
 	os.FileInfo
 	CustomName string
+	// Stores path to the source.
+	// Used when reading a symlink.
+	SourcePath string
 }
 
 // Name returns fi.CustomName if not empty;

--- a/tar.go
+++ b/tar.go
@@ -327,6 +327,7 @@ func (t *Tar) writeWalk(source, topLevelFolder, destination string) error {
 			FileInfo: FileInfo{
 				FileInfo:   info,
 				CustomName: nameInArchive,
+				SourcePath: fpath,
 			},
 			ReadCloser: file,
 		})
@@ -372,10 +373,14 @@ func (t *Tar) Write(f File) error {
 
 	var linkTarget string
 	if isSymlink(f) {
+		fi, ok := f.FileInfo.(FileInfo)
+		if !ok {
+			return fmt.Errorf("failed to cast fs.FileInfo to archiver.FileInfo: %v", f)
+		}
 		var err error
-		linkTarget, err = os.Readlink(f.Name())
+		linkTarget, err = os.Readlink(fi.SourcePath)
 		if err != nil {
-			return fmt.Errorf("%s: readlink: %v", f.Name(), err)
+			return fmt.Errorf("%s: readlink: %v", fi.SourcePath, err)
 		}
 	}
 


### PR DESCRIPTION
**Bug description:** 
When writing symlinks to .zip or .tar archive, Write method uses the archive path instead of real path to access a symlink on the file system. This causes errors like `readlink: readlink path/to/some/file: no such file or directory`.

**Bug fix:**
1. Added `SrcPath` field to `archiver.FileInfo` so that Write method can use it to read the symlink.
2. Added github actions for Ubuntu, MacOS and Windows for in-place test automation (this may be undone if required).