### PR TITLE
Add ExampleEmbed for ArchiveFS.Stream usage

### DIFF
--- a/fs_test.go
+++ b/fs_test.go
@@ -1,6 +1,16 @@
 package archiver
 
-import "testing"
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"net/http"
+	"path"
+	"testing"
+)
 
 func TestPathWithoutTopDir(t *testing.T) {
 	for i, tc := range []struct {
@@ -27,4 +37,36 @@ func TestPathWithoutTopDir(t *testing.T) {
 			t.Errorf("Test %d (input=%s): Expected '%s' but got '%s'", i, tc.input, tc.expect, actual)
 		}
 	}
+}
+
+//go:generate zip testdata/test.zip go.mod
+
+//go:embed testdata/test.zip
+var testZIP []byte
+
+func ExampleEmbed() {
+	fsys := ArchiveFS{
+		Stream: io.NewSectionReader(bytes.NewReader(testZIP), 0, int64(len(testZIP))),
+		Format: Zip{},
+	}
+	// You can serve the contents in a web server:
+	http.Handle("/static", http.StripPrefix("/static",
+		http.FileServer(http.FS(fsys))))
+
+	// Or read the files using fs functions:
+	dis, err := fsys.ReadDir(".")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, di := range dis {
+		fmt.Println(di.Name())
+		b, err := fs.ReadFile(fsys, path.Join(".", di.Name()))
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(bytes.Contains(b, []byte("require (")))
+	}
+	// Output:
+	// go.mod
+	// true
 }


### PR DESCRIPTION
For #307 (https://github.com/mholt/archiver/issues/307#issuecomment-1015110919): works very nice!

As a side note: can't happen that http.Dir is already what your DirFS tries to achieve?
net/http is a huge dependency, I wouldn't want to replace it, maybe just borrow the code, or look at the handling of some edge cases...