### PR TITLE
ignore empty root dir name when compressing file

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -77,6 +77,10 @@ func FilesFromDisk(options *FromDiskOptions, filenames map[string]string) ([]Fil
 			}
 
 			nameInArchive := nameOnDiskToNameInArchive(filename, rootOnDisk, rootInArchive)
+			// this is the root folder and we are adding its contents to target rootInArchive
+			if info.IsDir() && nameInArchive == "" {
+				return nil
+			}
 
 			// handle symbolic links
 			var linkTarget string


### PR DESCRIPTION
fix [350](https://github.com/mholt/archiver/issues/350)