### PR TITLE
zip: fix File.Open not working if called after zip.Extract completes

### DIFF
--- a/zip.go
+++ b/zip.go
@@ -202,6 +202,7 @@ func (z Zip) Extract(ctx context.Context, sourceArchive io.Reader, pathsInArchiv
 	skipDirs := skipList{}
 
 	for i, f := range zr.File {
+		f := f		// make a copy for the Open closure
 		if err := ctx.Err(); err != nil {
 			return err // honor context cancellation
 		}


### PR DESCRIPTION
The zip.Extract method creates a closure for the File.Open function
pointer sent to the handler method.

Unfortunately it uses the same File for each call to the handler
function which means that if the caller stores the File objects and
uses them after Extract has returned then each File.Open function
pointer will open the same object.

This is easily fixed by making sure that each iteration of the Extract
loop uses a new File variable.
