### PR TITLE
Rework ArchiveAsync interface to make it return any archiving errors

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -60,6 +60,13 @@ type Archiver interface {
 	Archive(ctx context.Context, output io.Writer, files []File) error
 }
 
+// ArchiveAsyncJob contains a File to be archived and a channel that
+// the result of the archiving should be returned on.
+type ArchiveAsyncJob struct {
+	File   File
+	Result chan<- error
+}
+
 // ArchiverAsync is an Archiver that can also create archives
 // asynchronously by pumping files into a channel as they are
 // discovered.
@@ -67,9 +74,11 @@ type ArchiverAsync interface {
 	Archiver
 
 	// Use ArchiveAsync if you can't pre-assemble a list of all
-	// the files for the archive. Close the files channel after
+	// the files for the archive. Close the jobs channel after
 	// all the files have been sent.
-	ArchiveAsync(ctx context.Context, output io.Writer, files <-chan File) error
+	//
+	// This won't return until the channel is closed.
+	ArchiveAsync(ctx context.Context, output io.Writer, jobs <-chan ArchiveAsyncJob) error
 }
 
 // Extractor can extract files from an archive.

--- a/tar.go
+++ b/tar.go
@@ -60,18 +60,12 @@ func (t Tar) Archive(ctx context.Context, output io.Writer, files []File) error 
 	return nil
 }
 
-func (t Tar) ArchiveAsync(ctx context.Context, output io.Writer, files <-chan File) error {
+func (t Tar) ArchiveAsync(ctx context.Context, output io.Writer, jobs <-chan ArchiveAsyncJob) error {
 	tw := tar.NewWriter(output)
 	defer tw.Close()
 
-	for file := range files {
-		if err := t.writeFileToArchive(ctx, tw, file); err != nil {
-			if t.ContinueOnError && ctx.Err() == nil { // context errors should always abort
-				log.Printf("[ERROR] %v", err)
-				continue
-			}
-			return err
-		}
+	for job := range jobs {
+		job.Result <- t.writeFileToArchive(ctx, tw, job.File)
 	}
 
 	return nil
@@ -234,7 +228,8 @@ func (t Tar) Extract(ctx context.Context, sourceArchive io.Reader, pathsInArchiv
 
 // Interface guards
 var (
-	_ Archiver  = (*Tar)(nil)
-	_ Extractor = (*Tar)(nil)
-	_ Inserter  = (*Tar)(nil)
+	_ Archiver      = (*Tar)(nil)
+	_ ArchiverAsync = (*Tar)(nil)
+	_ Extractor     = (*Tar)(nil)
+	_ Inserter      = (*Tar)(nil)
 )


### PR DESCRIPTION
This PR contains two commits

- Rework ArchiveAsync interface to make it return any archiving errors

After experience with the current ArchiveAsync interface while
creating an rclone backend it became clear that it wasn't quite right.
    
With the old interface, callers did not know when the File had been
archived and thus did not know when to release resources associated
with that file.
    
This patch changes the interface so that it returns the error
archiving each File. This means the caller can know when the File has
been archived and when to release resources. It returns the error for
each file archived which is useful too.
    
Fixes #368

- Add ArchiveAsync support to CompressedArchive
