### PR TITLE
Allow Identify to take a nil io.Reader

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -34,9 +34,11 @@ func (t Tar) Match(filename string, stream io.Reader) (MatchResult, error) {
 	}
 
 	// match file header
-	r := tar.NewReader(stream)
-	_, err := r.Next()
-	mr.ByStream = err == nil
+	if stream != nil {
+		r := tar.NewReader(stream)
+		_, err := r.Next()
+		mr.ByStream = err == nil
+	}
 
 	return mr, nil
 }


### PR DESCRIPTION
This PR contains two commits

- Allow Identify to take a nil io.Reader

Allow Identify to take a nil io.Reader
    
The Match functions can all take a nil io.Reader to mean just identify
the archive from its file name, but before this patch Identify could
not.
    
This patch allows the stream to be nil, and enables Identify to be
used to create formats for archives which haven't been created yet
just from their file name.

- Fix crash when Tar.Match is given a nil stream
