### PR TITLE
Option to use number for user and/or group names

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -17,11 +17,8 @@ func init() {
 }
 
 type Tar struct {
-	// If true, leave only numeric user id
-	NumericUid bool
-
-	// If true, leave only numeric group id
-	NumericGid bool
+	// If true, leave only numeric user and group id
+	NumericUidGid bool
 
 	// If true, errors encountered during reading or writing
 	// a file within an archive will be logged and the
@@ -87,10 +84,8 @@ func (t Tar) writeFileToArchive(ctx context.Context, tw *tar.Writer, file File) 
 		return fmt.Errorf("file %s: creating header: %w", file.NameInArchive, err)
 	}
 	hdr.Name = file.NameInArchive // complete path, since FileInfoHeader() only has base name
-	if t.NumericUid {
+	if t.NumericUidGid {
 		hdr.Uname = ""
-	}
-	if t.NumericGid {
 		hdr.Gname = ""
 	}
 

--- a/tar.go
+++ b/tar.go
@@ -17,8 +17,8 @@ func init() {
 }
 
 type Tar struct {
-	// If true, leave only numeric user and group id
-	NumericUidGid bool
+	// If true, preserve only numeric user and group id
+	NumericUIDGID bool
 
 	// If true, errors encountered during reading or writing
 	// a file within an archive will be logged and the
@@ -84,7 +84,7 @@ func (t Tar) writeFileToArchive(ctx context.Context, tw *tar.Writer, file File) 
 		return fmt.Errorf("file %s: creating header: %w", file.NameInArchive, err)
 	}
 	hdr.Name = file.NameInArchive // complete path, since FileInfoHeader() only has base name
-	if t.NumericUidGid {
+	if t.NumericUIDGID {
 		hdr.Uname = ""
 		hdr.Gname = ""
 	}

--- a/tar.go
+++ b/tar.go
@@ -17,6 +17,12 @@ func init() {
 }
 
 type Tar struct {
+	// If true, leave only numeric user id
+	NumericUid bool
+
+	// If true, leave only numeric group id
+	NumericGid bool
+
 	// If true, errors encountered during reading or writing
 	// a file within an archive will be logged and the
 	// operation will continue on remaining files.
@@ -71,7 +77,7 @@ func (t Tar) ArchiveAsync(ctx context.Context, output io.Writer, jobs <-chan Arc
 	return nil
 }
 
-func (Tar) writeFileToArchive(ctx context.Context, tw *tar.Writer, file File) error {
+func (t Tar) writeFileToArchive(ctx context.Context, tw *tar.Writer, file File) error {
 	if err := ctx.Err(); err != nil {
 		return err // honor context cancellation
 	}
@@ -81,6 +87,12 @@ func (Tar) writeFileToArchive(ctx context.Context, tw *tar.Writer, file File) er
 		return fmt.Errorf("file %s: creating header: %w", file.NameInArchive, err)
 	}
 	hdr.Name = file.NameInArchive // complete path, since FileInfoHeader() only has base name
+	if t.NumericUid {
+		hdr.Uname = ""
+	}
+	if t.NumericGid {
+		hdr.Gname = ""
+	}
 
 	if err := tw.WriteHeader(hdr); err != nil {
 		return fmt.Errorf("file %s: writing header: %w", file.NameInArchive, err)


### PR DESCRIPTION
* add NumericUid and NumericGid to Tar struct
* writeFileToArchive: set Uname and Gname to empty string if NumericUid and NumericGid are true, respectively.