### PR TITLE
zlib format incorrectly matches on ASCII files starting with the letter x

### DIFF
--- a/formats_test.go
+++ b/formats_test.go
@@ -371,6 +371,13 @@ func TestIdentifyFindFormatByStreamContent(t *testing.T) {
 			compressorName:        "",
 			wantFormatName:        ".rar",
 		},
+		{
+			name:                  "should recognize zz",
+			openCompressionWriter: Zlib{}.OpenWriter,
+			content:               []byte("this is text"),
+			compressorName:        ".zz",
+			wantFormatName:        ".zz",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/zlib.go
+++ b/zlib.go
@@ -1,7 +1,6 @@
 package archiver
 
 import (
-	"bytes"
 	"io"
 	"strings"
 
@@ -28,11 +27,13 @@ func (zz Zlib) Match(filename string, stream io.Reader) (MatchResult, error) {
 	}
 
 	// match file header
-	buf, err := readAtMost(stream, len(ZlibHeader))
-	if err != nil {
+	buf, err := readAtMost(stream, 2)
+	// If an error occurred or buf is not 2 bytes we can't check the header
+	if err != nil || len(buf) < 2 {
 		return mr, err
 	}
-	mr.ByStream = bytes.Equal(buf, ZlibHeader)
+
+	mr.ByStream = isValidZlibHeader(buf[0], buf[1])
 
 	return mr, nil
 }
@@ -49,4 +50,23 @@ func (Zlib) OpenReader(r io.Reader) (io.ReadCloser, error) {
 	return zlib.NewReader(r)
 }
 
-var ZlibHeader = []byte{0x78}
+func isValidZlibHeader(first, second byte) bool {
+	// Define all 32 valid zlib headers, see https://stackoverflow.com/questions/9050260/what-does-a-zlib-header-look-like/54915442#54915442
+	validHeaders := map[uint16]struct{}{
+		0x081D: {}, 0x085B: {}, 0x0899: {}, 0x08D7: {},
+		0x1819: {}, 0x1857: {}, 0x1895: {}, 0x18D3: {},
+		0x2815: {}, 0x2853: {}, 0x2891: {}, 0x28CF: {},
+		0x3811: {}, 0x384F: {}, 0x388D: {}, 0x38CB: {},
+		0x480D: {}, 0x484B: {}, 0x4889: {}, 0x48C7: {},
+		0x5809: {}, 0x5847: {}, 0x5885: {}, 0x58C3: {},
+		0x6805: {}, 0x6843: {}, 0x6881: {}, 0x68DE: {},
+		0x7801: {}, 0x785E: {}, 0x789C: {}, 0x78DA: {},
+	}
+
+	// Combine the first and second bytes into a single 16-bit, big-endian value
+	header := uint16(first)<<8 | uint16(second)
+
+	// Check if the header is in the map of valid headers
+	_, isValid := validHeaders[header]
+	return isValid
+}


### PR DESCRIPTION
Added a test to demonstrate a bug in the `Identify` routine where the zlib format incorrectly matches on ASCII files starting with the letter x (because ASCII x is the same as the first expected `byte` for ZlibHeader).

Unsure of how best to address.

The ZlibHeader match could be expanded to look at the second byte and verify it is one of the accepted values associated with the different compression levels.

Or could try and decompress the first part of the file using zlib? Not sure how robust that is, or how much you would need to read...maybe something like the following?
```
func (zz Zlib) Match(filename string, stream io.Reader) (MatchResult, error) {
	var mr MatchResult

	// match filename
	if strings.Contains(strings.ToLower(filename), zz.Name()) {
		mr.ByName = true
	}

	// match file header
	buf, err := readAtMost(stream, len(ZlibHeader))
	if err != nil {
		return mr, err
	}
	if bytes.Equal(buf, ZlibHeader) {
		// ZlibHeader can be accidentally matched by an ASCII file starting with the letter x
		// Try to decompress the first part of the stream to double check
		buf, err = readAtMost(stream, 4096)
		if err != nil {
			return mr, err
		}

		r, err := zlib.NewReader(bytes.NewReader(buf))
		if err != nil {
			return mr, nil // Not a zlib file
		}
		defer r.Close()

		_, err = io.ReadAll(r)
		if err == nil {
			mr.ByStream = true // Successfully decompressed, likely a zlib file
		}
	}

	return mr, nil
}
```