### PR TITLE
7z: Fix iteration bug

### DIFF
--- a/7z.go
+++ b/7z.go
@@ -82,6 +82,7 @@ func (z SevenZip) Extract(ctx context.Context, sourceArchive io.Reader, pathsInA
 	skipDirs := skipList{}
 
 	for i, f := range zr.File {
+		f := f // make a copy for the Open closure
 		if err := ctx.Err(); err != nil {
 			return err // honor context cancellation
 		}


### PR DESCRIPTION
7z: Fix iteration bug that was already fixed in go 1.22.
The bug is same as https://github.com/mholt/archiver/blob/master/zip.go#L199
