### PR TITLE
Fix tar path traversal through symlinks

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -8,7 +8,7 @@ jobs:
   
     strategy:
       matrix:
-        go-version: [1.13, 1.17]
+        go-version: [1.15]
     runs-on: macos-latest
     steps:
     - name: Install Go

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -8,7 +8,7 @@ jobs:
   
     strategy:
       matrix:
-        go-version: [1.15]
+        go-version: [1.21]
     runs-on: macos-latest
     steps:
     - name: Install Go

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -8,7 +8,7 @@ jobs:
   
     strategy:
       matrix:
-        go-version: [1.13, 1.17]
+        go-version: [1.15]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -8,7 +8,7 @@ jobs:
   
     strategy:
       matrix:
-        go-version: [1.15]
+        go-version: [1.21]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -8,7 +8,7 @@ jobs:
   
     strategy:
       matrix:
-        go-version: [1.13, 1.17]
+        go-version: [1.15]
     runs-on: windows-latest
     steps:
     - name: Install Go

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -8,7 +8,7 @@ jobs:
   
     strategy:
       matrix:
-        go-version: [1.15]
+        go-version: [1.21]
     runs-on: windows-latest
     steps:
     - name: Install Go

--- a/tar.go
+++ b/tar.go
@@ -238,6 +238,24 @@ func (t *Tar) untarNext(destination string) error {
 		return fmt.Errorf("checking path traversal attempt: %v", errPath)
 	}
 
+	switch header.Typeflag {
+	case tar.TypeSymlink, tar.TypeLink:
+		// this covers cases when the link is an absolute path to a file outside the destination folder
+		if filepath.IsAbs(header.Linkname) {
+			errPath := &IllegalPathError{AbsolutePath: "", Filename: header.Linkname}
+			return fmt.Errorf("absolute path for symlink destination not allowed: %w", errPath)
+		}
+
+		// though we've already checked the name for possible path traversals, it is possible
+		// to write content though a symlink to a path outside of the destination folder
+		// with multiple header entries. We should consider any symlink or hardlink that points
+		// to outside of the destination folder to be a possible path traversal attack.
+		errPath = t.CheckPath(destination, header.Linkname)
+		if errPath != nil {
+			return fmt.Errorf("checking path traversal attempt in symlink: %w", errPath)
+		}
+	}
+
 	if t.StripComponents > 0 {
 		if strings.Count(header.Name, "/") < t.StripComponents {
 			return nil // skip path with fewer components

--- a/tar_test.go
+++ b/tar_test.go
@@ -1,16 +1,26 @@
 package archiver_test
 
 import (
+	"archive/tar"
+	"bytes"
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/mholt/archiver/v3"
 )
 
+func requireDoesNotExist(t *testing.T, path string) {
+	_, err := os.Lstat(path)
+	if err == nil {
+		t.Fatalf("'%s' expected to not exist", path)
+	}
+}
+
 func requireRegularFile(t *testing.T, path string) os.FileInfo {
-	fileInfo, err := os.Stat(path)
+	fileInfo, err := os.Lstat(path)
 	if err != nil {
 		t.Fatalf("fileInfo on '%s': %v", path, err)
 	}
@@ -45,6 +55,83 @@ func TestDefaultTar_Unarchive_HardlinkSuccess(t *testing.T) {
 	fileaInfo := requireRegularFile(t, path.Join(destination, "dir-1", "dir-2", "file-a"))
 	filebInfo := requireRegularFile(t, path.Join(destination, "dir-1", "dir-2", "file-b"))
 	assertSameFile(t, fileaInfo, filebInfo)
+}
+
+func TestDefaultTar_Unarchive_SymlinkPathTraversal(t *testing.T) {
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "source.tar")
+	createSymlinkPathTraversalSample(t, source, "./../target")
+	destination := filepath.Join(tmp, "destination")
+
+	err := archiver.DefaultTar.Unarchive(source, destination)
+	if err != nil {
+		t.Fatalf("unarchiving '%s' to '%s': %v", source, destination, err)
+	}
+
+	requireDoesNotExist(t, filepath.Join(tmp, "target"))
+	requireRegularFile(t, filepath.Join(tmp, "destination", "duplicatedentry.txt"))
+}
+
+func TestDefaultTar_Unarchive_SymlinkPathTraversal_AbsLinkDestination(t *testing.T) {
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "source.tar")
+	createSymlinkPathTraversalSample(t, source, "/tmp/thing")
+	destination := filepath.Join(tmp, "destination")
+
+	err := archiver.DefaultTar.Unarchive(source, destination)
+	if err != nil {
+		t.Fatalf("unarchiving '%s' to '%s': %v", source, destination, err)
+	}
+
+	requireDoesNotExist(t, "/tmp/thing")
+	requireRegularFile(t, filepath.Join(tmp, "destination", "duplicatedentry.txt"))
+}
+
+func createSymlinkPathTraversalSample(t *testing.T, archivePath string, linkPath string) {
+	t.Helper()
+
+	type tarinfo struct {
+		Name string
+		Link string
+		Body string
+		Type byte
+	}
+
+	var infos = []tarinfo{
+		{"duplicatedentry.txt", linkPath, "", tar.TypeSymlink},
+		{"duplicatedentry.txt", "", "content modified!", tar.TypeReg},
+	}
+
+	var buf bytes.Buffer
+	var tw = tar.NewWriter(&buf)
+	for _, ti := range infos {
+		hdr := &tar.Header{
+			Name:     ti.Name,
+			Mode:     0600,
+			Linkname: ti.Link,
+			Typeflag: ti.Type,
+			Size:     int64(len(ti.Body)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal("Writing header: ", err)
+		}
+		if _, err := tw.Write([]byte(ti.Body)); err != nil {
+			t.Fatal("Writing body: ", err)
+		}
+	}
+
+	f, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = f.Write(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestDefaultTar_Extract_HardlinkSuccess(t *testing.T) {

--- a/tar_test.go
+++ b/tar_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/mholt/archiver/v3"
@@ -75,7 +76,13 @@ func TestDefaultTar_Unarchive_SymlinkPathTraversal(t *testing.T) {
 func TestDefaultTar_Unarchive_SymlinkPathTraversal_AbsLinkDestination(t *testing.T) {
 	tmp := t.TempDir()
 	source := filepath.Join(tmp, "source.tar")
-	createSymlinkPathTraversalSample(t, source, "/tmp/thing")
+
+	linkPath := "/tmp/thing"
+	if runtime.GOOS == "windows" {
+		linkPath = "C:\\tmp\\thing"
+	}
+
+	createSymlinkPathTraversalSample(t, source, linkPath)
 	destination := filepath.Join(tmp, "destination")
 
 	err := archiver.DefaultTar.Unarchive(source, destination)


### PR DESCRIPTION
This PR addresses behavior of `archiver.Tar.Unarchive()` described in CVE-2024-0406, specifically in two cases:

**Case 1**

When a tar contains two header entries for the same file:

1.  the first entry, with path `./x`, is a symlink that points relatively outside of the unarchive destination (e.g. `../../../here`)
2. the second entry, also with path `./x`, is a regular file 

This will result in the symlink being created in the first pass, then the second entry writing contents to a potentially new file (or overwrite an existing file) outside of the unarchive destination

**Case 2**

When a tar contains a link that points to an absolute path (e.g. `/bin/here`). In this case it is unlikely that this path is within the unarchive destination.

**Changes**

This PR changes the behavior by:
- not writing out symlinks with link destination names that are absolute paths
- not writing out symlinks with link destination names that are relative paths that resolve to outside of the unarchive directory 
