### PR TITLE
Error messages: add new lines

### DIFF
--- a/7z.go
+++ b/7z.go
@@ -111,7 +111,7 @@ func (z SevenZip) Extract(ctx context.Context, sourceArchive io.Reader, pathsInA
 			skipDirs.add(dirPath)
 		} else if err != nil {
 			if z.ContinueOnError {
-				log.Printf("[ERROR] %s: %v", f.Name, err)
+				log.Printf("[ERROR] %s: %v\n", f.Name, err)
 				continue
 			}
 			return fmt.Errorf("handling file %d: %s: %w", i, f.Name, err)

--- a/rar.go
+++ b/rar.go
@@ -86,7 +86,7 @@ func (r Rar) Extract(ctx context.Context, sourceArchive io.Reader, pathsInArchiv
 		}
 		if err != nil {
 			if r.ContinueOnError {
-				log.Printf("[ERROR] Advancing to next file in rar archive: %v", err)
+				log.Printf("[ERROR] Advancing to next file in rar archive: %v\n", err)
 				continue
 			}
 			return err

--- a/tar.go
+++ b/tar.go
@@ -53,7 +53,7 @@ func (t Tar) Archive(ctx context.Context, output io.Writer, files []File) error 
 	for _, file := range files {
 		if err := t.writeFileToArchive(ctx, tw, file); err != nil {
 			if t.ContinueOnError && ctx.Err() == nil { // context errors should always abort
-				log.Printf("[ERROR] %v", err)
+				log.Printf("[ERROR] %v\n", err)
 				continue
 			}
 			return err
@@ -169,7 +169,7 @@ func (t Tar) Insert(ctx context.Context, into io.ReadWriteSeeker, files []File) 
 		err = t.writeFileToArchive(ctx, tw, file)
 		if err != nil {
 			if t.ContinueOnError && ctx.Err() == nil {
-				log.Printf("[ERROR] appending file %d into archive: %s: %v", i, file.Name(), err)
+				log.Printf("[ERROR] appending file %d into archive: %s: %v\n", i, file.Name(), err)
 				continue
 			}
 			return fmt.Errorf("appending file %d into archive: %s: %w", i, file.Name(), err)
@@ -196,7 +196,7 @@ func (t Tar) Extract(ctx context.Context, sourceArchive io.Reader, pathsInArchiv
 		}
 		if err != nil {
 			if t.ContinueOnError && ctx.Err() == nil {
-				log.Printf("[ERROR] Advancing to next file in tar archive: %v", err)
+				log.Printf("[ERROR] Advancing to next file in tar archive: %v\n", err)
 				continue
 			}
 			return err

--- a/zip.go
+++ b/zip.go
@@ -233,7 +233,7 @@ func (z Zip) Extract(ctx context.Context, sourceArchive io.Reader, pathsInArchiv
 			skipDirs.add(dirPath)
 		} else if err != nil {
 			if z.ContinueOnError {
-				log.Printf("[ERROR] %s: %v", f.Name, err)
+				log.Printf("[ERROR] %s: %v\n", f.Name, err)
 				continue
 			}
 			return fmt.Errorf("handling file %d: %s: %w", i, f.Name, err)
@@ -311,7 +311,7 @@ func (z Zip) Insert(ctx context.Context, into io.ReadWriteSeeker, files []File) 
 		}
 		if err := openAndCopyFile(file, w); err != nil {
 			if z.ContinueOnError && ctx.Err() == nil {
-				log.Printf("[ERROR] appending file %d into archive: %s: %v", idx, file.Name(), err)
+				log.Printf("[ERROR] appending file %d into archive: %s: %v\n", idx, file.Name(), err)
 				continue
 			}
 			return fmt.Errorf("copying inserted file %d: %s: %w", idx, file.Name(), err)


### PR DESCRIPTION
When extracting a large archive with many ignored errors through syft the errors do not go to the next line which is hard to read.

Add trailing new line.

(cc @wagoodman for heads up as this is mostly for syft -- assuming it'll get in eventually after merging here anyway but might as well be aware)