### PR TITLE
chore(go.mod): Switch to upstream lzip package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/STARRY-S/zip v0.1.0
 	github.com/bodgit/sevenzip v1.5.1
 	github.com/golang/snappy v0.0.4
-	github.com/mholt/lzip-go v0.3.6
 	github.com/pierrec/lz4/v4 v4.1.21
+	github.com/sorairolake/lzip-go v0.3.5
 	golang.org/x/text v0.16.0
 )
 
@@ -29,6 +29,5 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
-	github.com/sorairolake/lzip-go v0.3.5 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,6 @@ github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQ
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/mholt/lzip-go v0.3.6 h1:M32wuPUoU7OWXMFukNnK/OZRXdPQyZsdn9ls/Gqivts=
-github.com/mholt/lzip-go v0.3.6/go.mod h1:E5mRuN06hLueqwJepeuv1xf2X5GnW9xd+Qs+JJBDGBM=
 github.com/nwaples/rardecode/v2 v2.0.0-beta.2 h1:e3mzJFJs4k83GXBEiTaQ5HgSc/kOK8q0rDaRO0MPaOk=
 github.com/nwaples/rardecode/v2 v2.0.0-beta.2/go.mod h1:yntwv/HfMc/Hbvtq9I19D1n58te3h6KsqCf3GxyfBGY=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=

--- a/lzip.go
+++ b/lzip.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mholt/lzip-go"
+	"github.com/sorairolake/lzip-go"
 )
 
 func init() {


### PR DESCRIPTION
This reverts commit a902fcc00a188fb940b75bb3db65a2cb44636a58.

See also #421.